### PR TITLE
Added flag -restart-container to allow restarting of docker containers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ docker-gen
 Usage: docker-gen [options] <template> [<dest>]
 ```
 
-[-config file] [-watch=false] [-notify="restart xyz"] [-interval=0] [-endpoint tcp|unix://..]
+[-config file] [-watch=false] [-notify="restart xyz"] [-notify-sighup="nginx-proxy"] [-interval=0] [-endpoint tcp|unix://..]
 
 *Options:*
 ```
@@ -50,6 +50,7 @@ Usage: docker-gen [options] <template> [<dest>]
   -interval=0:run notify command interval (s). Useful for service registration use cases.
   -notify="": run command after template is regenerated ["restart xyz"]. Useful for restarting nginx,
               reloading haproxy, etc..
+  -notify-sighup="": send HUP signal to container.  Equivalent to `docker kill -s HUP container-ID`
   -only-exposed=false: only include containers with exposed ports
   -only-published=false: only include containers with published ports (implies -only-exposed)
   -version=false: show version


### PR DESCRIPTION
Continued from #24 (code is moved from master branch)

...

The main purpose of this patch is too be able to run docker-gen by itself in a container. Therefore I think it is vital that this functionality is built into docker-gen and not provided by an external dependency (script/program). The external dependency provides an additional tool to maintain (ensuring the docker end point is available, ensure API calls are up to date etc.) and package.

I would really like to see this patch accepted, as it would make docker-gen much more usable (certainly for me and cnf!).

I agree with the syntax being funky, and have thought a bit more about the additional flag, and perhaps it is the only way to go. If we can agree, I will rewrite the patch to include a new flag: -restart-container=CONTAINER_ID. 
So either the flag or old flag, both or none can be specified and all behaves as it did before. If both are specified then it issues the restart and the notify.
