### PR TITLE
Set correct permissions on <dest> file creation

### DIFF
--- a/template.go
+++ b/template.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"text/template"
 )
 
@@ -107,7 +108,13 @@ func generateFile(config Config, containers Context) bool {
 	if config.Dest != "" {
 
 		contents := []byte{}
-		if _, err := os.Stat(config.Dest); err == nil {
+		if fi, err := os.Stat(config.Dest); err == nil {
+			if err := dest.Chmod(fi.Mode()); err != nil {
+				log.Printf("unable to chmod temp file: %s\n", err)
+			}
+			if err := dest.Chown(int(fi.Sys().(*syscall.Stat_t).Uid), int(fi.Sys().(*syscall.Stat_t).Gid)); err != nil {
+				log.Printf("unable to chown temp file: %s\n", err)
+			}
 			contents, err = ioutil.ReadFile(config.Dest)
 			if err != nil {
 				log.Fatalf("unable to compare current file contents: %s: %s\n", config.Dest, err)


### PR DESCRIPTION
The creation of a new output file each time the config changes causes problems with its ownership and permissions; when the output file is on a Docker volume.
Without doing additional user adding/user space mapping stuff, Docker writes the file as root:root and 0600, which for all sense and purposes makes it unreadable for everything else.
If a file already exists, then the file's ownership and permissions are left untouched by Docker.

I couldn't see why a temp file was being used so this patch removes the use of it, and instead will truncate and overwrite the existing file.
