### PR TITLE
Adding 'replace' as a template-usable function

### DIFF
--- a/template.go
+++ b/template.go
@@ -63,6 +63,7 @@ func generateFile(config Config, containers Context) bool {
 		"groupBy":      groupBy,
 		"groupByMulti": groupByMulti,
 		"split":        strings.Split,
+		"replace":      strings.Replace,
 	}).ParseFiles(templatePath)
 	if err != nil {
 		log.Fatalf("unable to parse template: %s", err)


### PR DESCRIPTION
This is necessary for safe-ing characters in e.g. a docker container name that you're putting into `etcd` as a key
