### PR TITLE
Add doc for emitted object by docker-gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If no `<dest>` file is specified, the output is sent to stdout.  Mainly useful f
 
 The templates used by docker-gen are written using the Go [text/template](http://golang.org/pkg/text/template/) language. In addition to the [built-in functions](http://golang.org/pkg/text/template/#hdr-Functions) supplied by Go, docker-gen provides a number of additional functions to make it simpler (or possible) to generate your desired output.
 
-Within those templates, the object emitted by docker-gen will have [this structure ](https://github.com/jwilder/docker-gen/wiki/Docker-Gen-Emit-Structure).
+Within those templates, the object emitted by docker-gen will have [this structure](https://github.com/jwilder/docker-gen/wiki/Docker-Gen-Emit-Structure).
 
 #### Functions
 


### PR DESCRIPTION
The reason for this is to know the object structure without diving into the source code. Which wasn't that hard but some doc is still handy.
