### PR TITLE
Add functions to handle string prefixes and suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Within those templates, the object emitted by docker-gen will have [this structu
 * *`replace $string $old $new $count`*: Replaces up to `$count` occurences of `$old` with `$new` in `$string`. Alias for [`strings.Replace`](http://golang.org/pkg/strings/#Replace)
 * *`sha1 $string`*: Returns the hexadecimal representation of the SHA1 hash of `$string`.
 * *`split $string $sep`*: Splits `$string` into a slice of substrings delimited by `$sep`. Alias for [`strings.Split`](http://golang.org/pkg/strings/#Split)
+* *`trimPrefix $prefix $string`*: If `$prefix` is a prefix of `$string`, return `$string` with `$prefix` trimmed from the beginning. Otherwise, return `$string` unchanged.
+* *`trimSuffix $suffix $string`*: If `$suffix` is a suffix of `$string`, return `$string` with `$suffix` trimmed from the end. Otherwise, return `$string` unchanged.
 
 ===
 

--- a/template.go
+++ b/template.go
@@ -169,6 +169,16 @@ func coalesce(input ...interface{}) interface{} {
 	return nil
 }
 
+// trimPrefix returns whether a given string is a prefix of another string
+func trimPrefix(prefix, s string) string {
+	return strings.TrimPrefix(s, prefix)
+}
+
+// trimSuffix returns whether a given string is a suffix of another string
+func trimSuffix(suffix, s string) string {
+	return strings.TrimSuffix(s, suffix)
+}
+
 func generateFile(config Config, containers Context) bool {
 	templatePath := config.Template
 	tmpl, err := template.New(filepath.Base(templatePath)).Funcs(template.FuncMap{
@@ -189,6 +199,8 @@ func generateFile(config Config, containers Context) bool {
 		"replace":      strings.Replace,
 		"sha1":         hashSha1,
 		"split":        strings.Split,
+		"trimPrefix":   trimPrefix,
+		"trimSuffix":   trimSuffix,
 	}).ParseFiles(templatePath)
 	if err != nil {
 		log.Fatalf("unable to parse template: %s", err)

--- a/template_test.go
+++ b/template_test.go
@@ -120,6 +120,26 @@ func TestHasSuffix(t *testing.T) {
 	}
 }
 
+func TestTrimPrefix(t *testing.T) {
+	const prefix = "tcp://"
+	const str = "tcp://127.0.0.1:2375"
+	const trimmed = "127.0.0.1:2375"
+	got := trimPrefix(prefix, str)
+	if got != trimmed {
+		t.Fatalf("expected trimPrefix(%s,%s) to be %s, got %s", prefix, str, trimmed, got)
+	}
+}
+
+func TestTrimSuffix(t *testing.T) {
+	const suffix = ".local"
+	const str = "myhost.local"
+	const trimmed = "myhost"
+	got := trimSuffix(suffix, str)
+	if got != trimmed {
+		t.Fatalf("expected trimSuffix(%s,%s) to be %s, got %s", suffix, str, trimmed, got)
+	}
+}
+
 func TestDict(t *testing.T) {
 	containers := []*RuntimeContainer{
 		&RuntimeContainer{


### PR DESCRIPTION
Introduces the following functions:
- `hasPrefix $prefix $s`
- `hasSuffix $suffix $s`
- `trimPrefix $prefix $s`
- `trimSuffix $suffix $s`

These call the corresponding `strings.{Has,Trim}*` functions with the arguments flipped to better facilitate function pipelining for template usage (e.g. `$val := split $input $sep | first | trimSuffix $suffix`).
