### PR TITLE
Add Volumes to RuntimeContainer

### DIFF
--- a/docker-gen.go
+++ b/docker-gen.go
@@ -47,6 +47,12 @@ type Address struct {
 	Proto    string
 }
 
+type Volume struct {
+	Path      string
+	HostPath  string
+	ReadWrite bool
+}
+
 type RuntimeContainer struct {
 	ID        string
 	Addresses []Address
@@ -54,6 +60,7 @@ type RuntimeContainer struct {
 	Name      string
 	Image     DockerImage
 	Env       map[string]string
+	Volumes   map[string]Volume
 }
 
 type DockerImage struct {

--- a/docker_client.go
+++ b/docker_client.go
@@ -124,6 +124,7 @@ func getContainers(client *docker.Client) ([]*RuntimeContainer, error) {
 			Gateway:   container.NetworkSettings.Gateway,
 			Addresses: []Address{},
 			Env:       make(map[string]string),
+			Volumes:   make(map[string]Volume),
 		}
 		for k, v := range container.NetworkSettings.Ports {
 			address := Address{
@@ -137,6 +138,13 @@ func getContainers(client *docker.Client) ([]*RuntimeContainer, error) {
 			runtimeContainer.Addresses = append(runtimeContainer.Addresses,
 				address)
 
+		}
+		for k, v := range container.Volumes {
+			runtimeContainer.Volumes[k] = Volume{
+				Path:      k,
+				HostPath:  v,
+				ReadWrite: container.VolumesRW[k],
+			}
 		}
 
 		for _, entry := range container.Config.Env {


### PR DESCRIPTION
This adds a `Volumes` field to the `RuntimeContainer` struct, consisting of a `map[string]Volume`.

This could probably benefit from some tests, but there weren't any existing `getContainer` tests to add to. We'll also want to document the changes to `RuntimeContainer` and the new `Volume` struct on [the wiki](https://github.com/jwilder/docker-gen/wiki/Docker-Gen-Emit-Structure).

Fixes #20.
