### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+go:
+- 1.3
+- 1.4
+- tip
+install:
+- make get-deps
+script:
+- make all test

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,10 @@ release: dist
 	tar -cvzf docker-gen-linux-armhf-$(TAG).tar.gz -C dist/linux/armhf docker-gen
 	tar -cvzf docker-gen-darwin-amd64-$(TAG).tar.gz -C dist/darwin/amd64 docker-gen
 	tar -cvzf docker-gen-darwin-i386-$(TAG).tar.gz -C dist/darwin/i386 docker-gen
+
+get-deps:
+	go get github.com/robfig/glock
+	glock sync -n < GLOCKFILE
+
+test:
+	go test


### PR DESCRIPTION
This PR adds configuration for [Travis CI](https://travis-ci.org).

The tests on [my Travis setup](https://travis-ci.org/md5/docker-gen/builds/48577781) are currently failing, but that's because `getEndpoint` is calling `exists` on `/var/run/docker.sock` and Docker isn't running in the Travis environment. I have a similar issue with that same test failing locally because I'm running boot2docker and my `DOCKER_HOST` is set to point to my b2d VM.

Travis would still need to be turned on for `jwilder/docker-gen` for this to work.