### PR TITLE
Remove exists() from getEndpoint()

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"os"
 )
 
@@ -15,20 +14,9 @@ func getEndpoint() (string, error) {
 		defaultEndpoint = endpoint
 	}
 
-	proto, host, err := parseHost(defaultEndpoint)
+	_, _, err := parseHost(defaultEndpoint)
 	if err != nil {
 		return "", err
-	}
-
-	if proto == "unix" {
-		exist, err := exists(host)
-		if err != nil {
-			return "", err
-		}
-
-		if !exist {
-			return "", errors.New(host + " does not exist")
-		}
 	}
 
 	return defaultEndpoint, nil

--- a/utils_test.go
+++ b/utils_test.go
@@ -55,20 +55,6 @@ func TestDockerFlagEndpoint(t *testing.T) {
 	}
 }
 
-func TestUnixNotExists(t *testing.T) {
-
-	endpoint = ""
-	err := os.Setenv("DOCKER_HOST", "unix:///does/not/exist")
-	if err != nil {
-		t.Fatalf("Unable to set DOCKER_HOST: %s", err)
-	}
-
-	_, err = getEndpoint()
-	if err == nil {
-		t.Fatal("endpoint should have failed")
-	}
-}
-
 func TestUnixBadFormat(t *testing.T) {
 	endpoint = "unix:/var/run/docker.sock"
 	_, err := getEndpoint()


### PR DESCRIPTION
Should fix tests running under travis build and boot2docker where
unix:///var/run/docker.sock does not exist.

exists was not necessary since connecting to a non-existent unix
socket would fail anyways and is already handled.