### PR TITLE
Added whereExist and whereNotExist

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Within those templates, the object emitted by docker-gen will have [this structu
 * *`trimPrefix $prefix $string`*: If `$prefix` is a prefix of `$string`, return `$string` with `$prefix` trimmed from the beginning. Otherwise, return `$string` unchanged.
 * *`trimSuffix $suffix $string`*: If `$suffix` is a suffix of `$string`, return `$string` with `$suffix` trimmed from the end. Otherwise, return `$string` unchanged.
 * *`where $containers $fieldPath $value`*: Filters an array of `RuntimeContainer` instances based on the values of a field path expression `$fieldPath`. A field path expression is a dot-delimited list of map keys or struct member names specifying the path from container to a nested value, which must be a string. Returns an array of containers having that value.
+* *`whereExist $containers $fieldPath`*: Like `where`, but returns only containers where `$fieldPath` exists (is not nil).
+* *`whereNotExist $containers $fieldPath`*: Like `where`, but returns only containers where `$fieldPath` does not exist (is nil).
 * *`whereAny $containers $fieldPath $sep $values`*: Like `where`, but the string value specified by `$fieldPath` is first split by `$sep` into a list of strings. The comparison value is a string slice with possible matches. Returns containers which OR intersect these values.
 * *`whereAll $containers $fieldPath $sep $values`*: Like `whereAny`, except all `$values` must exist in the `$fieldPath`.
 

--- a/template.go
+++ b/template.go
@@ -77,6 +77,30 @@ func where(entries []*RuntimeContainer, key string, cmp string) []*RuntimeContai
 	return selection
 }
 
+// selects entries where a key exists
+func whereExist(entries []*RuntimeContainer, key string) []*RuntimeContainer {
+	selection := []*RuntimeContainer{}
+	for _, v := range entries {
+		value := deepGet(*v, key)
+		if value != nil {
+			selection = append(selection, v)
+		}
+	}
+	return selection
+}
+
+// selects entries where a key does not exist
+func whereNotExist(entries []*RuntimeContainer, key string) []*RuntimeContainer {
+	selection := []*RuntimeContainer{}
+        for _, v := range entries {
+                value := deepGet(*v, key)
+                if value == nil {
+                        selection = append(selection, v)
+                }
+        }
+        return selection
+}
+
 // selects entries based on key.  Assumes key is delimited and breaks it apart before comparing
 func whereAny(entries []*RuntimeContainer, key, sep string, cmp []string) []*RuntimeContainer {
 	selection := []*RuntimeContainer{}
@@ -284,6 +308,8 @@ func generateFile(config Config, containers Context) bool {
 		"trimPrefix":   trimPrefix,
 		"trimSuffix":   trimSuffix,
 		"where":        where,
+		"whereExist":	whereExist,
+		"whereNotExist":	whereNotExist,
 		"whereAny":     whereAny,
 		"whereAll":     whereAll,
 	}).ParseFiles(templatePath)

--- a/template_test.go
+++ b/template_test.go
@@ -221,6 +221,100 @@ func TestWhere(t *testing.T) {
 	}
 }
 
+func TestWhereExist(t *testing.T) {
+	containers := []*RuntimeContainer{
+		&RuntimeContainer{
+			Env: map[string]string{
+				"VIRTUAL_HOST": "demo1.localhost",
+				"VIRTUAL_PATH": "/api",
+			},
+			ID: "1",
+		},
+		&RuntimeContainer{
+			Env: map[string]string{
+				"VIRTUAL_HOST": "demo2.localhost",
+			},
+			ID: "2",
+		},
+		&RuntimeContainer{
+			Env: map[string]string{
+				"VIRTUAL_HOST": "demo3.localhost",
+				"VIRTUAL_PATH": "/api",
+			},
+			ID: "3",
+		},
+		&RuntimeContainer{
+			Env: map[string]string{
+				"VIRTUAL_PROTO": "https",
+			},
+			ID: "4",
+		},
+	}
+
+	if len(whereExist(containers, "Env.VIRTUAL_HOST")) != 3 {
+		t.Fatalf("Env.VIRTUAL_HOST expected 3 matches")
+	}
+
+	if len(whereExist(containers, "Env.VIRTUAL_PATH")) != 2 {
+		t.Fatalf("Env.VIRTUAL_PATH expected 2 matches")
+	}
+
+	if len(whereExist(containers, "Env.NOT_A_KEY")) != 0 {
+		t.Fatalf("Env.NOT_A_KEY expected 0 matches")
+	}
+
+	if len(whereExist(containers, "Env.VIRTUAL_PROTO")) != 1 {
+		t.Fatalf("Env.VIRTUAL_PROTO expected 1 matche")
+	}
+}
+
+func TestWhereNotExist(t *testing.T) {
+	containers := []*RuntimeContainer{
+		&RuntimeContainer{
+			Env: map[string]string{
+				"VIRTUAL_HOST": "demo1.localhost",
+				"VIRTUAL_PATH": "/api",
+			},
+			ID: "1",
+		},
+		&RuntimeContainer{
+			Env: map[string]string{
+				"VIRTUAL_HOST": "demo2.localhost",
+			},
+			ID: "2",
+		},
+		&RuntimeContainer{
+			Env: map[string]string{
+				"VIRTUAL_HOST": "demo3.localhost",
+				"VIRTUAL_PATH": "/api",
+			},
+			ID: "3",
+		},
+		&RuntimeContainer{
+			Env: map[string]string{
+				"VIRTUAL_PROTO": "https",
+			},
+			ID: "4",
+		},
+	}
+
+	if len(whereNotExist(containers, "Env.VIRTUAL_HOST")) != 1 {
+		t.Fatalf("Env.VIRTUAL_HOST expected 1 match")
+	}
+
+	if len(whereNotExist(containers, "Env.VIRTUAL_PATH")) != 2 {
+		t.Fatalf("Env.VIRTUAL_PATH expected 2 matches")
+	}
+
+	if len(whereNotExist(containers, "Env.NOT_A_KEY")) != 4 {
+		t.Fatalf("Env.NOT_A_KEY expected 4 matches")
+	}
+
+	if len(whereNotExist(containers, "Env.VIRTUAL_PROTO")) != 3 {
+		t.Fatalf("Env.VIRTUAL_PROTO expected 3 matches")
+	}
+}
+
 func TestWhereSomeMatch(t *testing.T) {
 	containers := []*RuntimeContainer{
 		&RuntimeContainer{


### PR DESCRIPTION
This includes template helpers `whereExist` and `whereNotExist`.  I found myself looking for containers that did not have an environment variable and wanted an easy way to query containers (existing `where` function didn't seem to work with `""` or `nil`).