### PR TITLE
Separate newTemplate from generateFile

### DIFF
--- a/template.go
+++ b/template.go
@@ -283,9 +283,8 @@ func trimSuffix(suffix, s string) string {
 	return strings.TrimSuffix(s, suffix)
 }
 
-func generateFile(config Config, containers Context) bool {
-	templatePath := config.Template
-	tmpl, err := template.New(filepath.Base(templatePath)).Funcs(template.FuncMap{
+func newTemplate(name string) *template.Template {
+	tmpl := template.New(name).Funcs(template.FuncMap{
 		"closest":       arrayClosest,
 		"coalesce":      coalesce,
 		"contains":      contains,
@@ -312,7 +311,13 @@ func generateFile(config Config, containers Context) bool {
 		"whereNotExist": whereNotExist,
 		"whereAny":      whereAny,
 		"whereAll":      whereAll,
-	}).ParseFiles(templatePath)
+	})
+	return tmpl
+}
+
+func generateFile(config Config, containers Context) bool {
+	templatePath := config.Template
+	tmpl, err := newTemplate(filepath.Base(templatePath)).ParseFiles(templatePath)
 	if err != nil {
 		log.Fatalf("unable to parse template: %s", err)
 	}

--- a/template_test.go
+++ b/template_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+	"text/template"
 )
 
 func TestContains(t *testing.T) {
@@ -27,20 +28,16 @@ func TestKeys(t *testing.T) {
 		expected: "demo.local",
 	}
 
-	k, err := keys(env)
+	const text = "{{range (keys $)}}{{.}}{{end}}"
+	tmpl := template.Must(newTemplate("keys-test").Parse(text))
+
+	var b bytes.Buffer
+	err := tmpl.ExecuteTemplate(&b, "keys-test", env)
 	if err != nil {
-		t.Fatalf("Error fetching keys: %v", err)
-	}
-	vk := reflect.ValueOf(k)
-	if vk.Kind() == reflect.Invalid {
-		t.Fatalf("Got invalid kind for keys: %v", vk)
+		t.Fatalf("Error executing template: %v", err)
 	}
 
-	if len(env) != vk.Len() {
-		t.Fatalf("Incorrect key count; expected %s, got %s", len(env), vk.Len())
-	}
-
-	got := vk.Index(0).Interface()
+	got := b.String()
 	if expected != got {
 		t.Fatalf("Incorrect key found; expected %s, got %s", expected, got)
 	}


### PR DESCRIPTION
I originally wrote this code as the start of an effort to allow sub-template includes, but I'm pushing it as a separate PR since it's useful for testing (see included test update for `TestKeys`).