### PR TITLE
Add parseJson function

### DIFF
--- a/template.go
+++ b/template.go
@@ -283,9 +283,8 @@ func trimSuffix(suffix, s string) string {
 	return strings.TrimSuffix(s, suffix)
 }
 
-func generateFile(config Config, containers Context) bool {
-	templatePath := config.Template
-	tmpl, err := template.New(filepath.Base(templatePath)).Funcs(template.FuncMap{
+func newTemplate(name string) *template.Template {
+	tmpl := template.New(name).Funcs(template.FuncMap{
 		"closest":       arrayClosest,
 		"coalesce":      coalesce,
 		"contains":      contains,
@@ -312,7 +311,13 @@ func generateFile(config Config, containers Context) bool {
 		"whereNotExist": whereNotExist,
 		"whereAny":      whereAny,
 		"whereAll":      whereAll,
-	}).ParseFiles(templatePath)
+	})
+	return tmpl
+}
+
+func generateFile(config Config, containers Context) bool {
+	templatePath := config.Template
+	tmpl, err := newTemplate(filepath.Base(templatePath)).ParseFiles(templatePath)
 	if err != nil {
 		log.Fatalf("unable to parse template: %s", err)
 	}

--- a/template.go
+++ b/template.go
@@ -216,6 +216,22 @@ func marshalJson(input interface{}) (string, error) {
 	return strings.TrimSuffix(buf.String(), "\n"), nil
 }
 
+func unmarshalJsonArray(input string) ([]interface{}, error) {
+	var v []interface{}
+	if err := json.Unmarshal([]byte(input), &v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func unmarshalJsonObject(input string) (interface{}, error) {
+	var v map[string]interface{}
+	if err := json.Unmarshal([]byte(input), &v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
 // arrayFirst returns first item in the array or nil if the
 // input is nil or empty
 func arrayFirst(input interface{}) interface{} {
@@ -285,32 +301,34 @@ func trimSuffix(suffix, s string) string {
 
 func newTemplate(name string) *template.Template {
 	tmpl := template.New(name).Funcs(template.FuncMap{
-		"closest":       arrayClosest,
-		"coalesce":      coalesce,
-		"contains":      contains,
-		"dict":          dict,
-		"dir":           dirList,
-		"exists":        exists,
-		"first":         arrayFirst,
-		"groupBy":       groupBy,
-		"groupByKeys":   groupByKeys,
-		"groupByMulti":  groupByMulti,
-		"hasPrefix":     hasPrefix,
-		"hasSuffix":     hasSuffix,
-		"json":          marshalJson,
-		"intersect":     intersect,
-		"keys":          keys,
-		"last":          arrayLast,
-		"replace":       strings.Replace,
-		"sha1":          hashSha1,
-		"split":         strings.Split,
-		"trimPrefix":    trimPrefix,
-		"trimSuffix":    trimSuffix,
-		"where":         where,
-		"whereExist":    whereExist,
-		"whereNotExist": whereNotExist,
-		"whereAny":      whereAny,
-		"whereAll":      whereAll,
+		"closest":         arrayClosest,
+		"coalesce":        coalesce,
+		"contains":        contains,
+		"dict":            dict,
+		"dir":             dirList,
+		"exists":          exists,
+		"first":           arrayFirst,
+		"groupBy":         groupBy,
+		"groupByKeys":     groupByKeys,
+		"groupByMulti":    groupByMulti,
+		"hasPrefix":       hasPrefix,
+		"hasSuffix":       hasSuffix,
+		"json":            marshalJson,
+		"intersect":       intersect,
+		"keys":            keys,
+		"last":            arrayLast,
+		"replace":         strings.Replace,
+		"parseJsonArray":  unmarshalJsonArray,
+		"parseJsonObject": unmarshalJsonObject,
+		"sha1":            hashSha1,
+		"split":           strings.Split,
+		"trimPrefix":      trimPrefix,
+		"trimSuffix":      trimSuffix,
+		"where":           where,
+		"whereExist":      whereExist,
+		"whereNotExist":   whereNotExist,
+		"whereAny":        whereAny,
+		"whereAll":        whereAll,
 	})
 	return tmpl
 }

--- a/template.go
+++ b/template.go
@@ -216,16 +216,8 @@ func marshalJson(input interface{}) (string, error) {
 	return strings.TrimSuffix(buf.String(), "\n"), nil
 }
 
-func unmarshalJsonArray(input string) ([]interface{}, error) {
-	var v []interface{}
-	if err := json.Unmarshal([]byte(input), &v); err != nil {
-		return nil, err
-	}
-	return v, nil
-}
-
-func unmarshalJsonObject(input string) (interface{}, error) {
-	var v map[string]interface{}
+func unmarshalJson(input string) (interface{}, error) {
+	var v interface{}
 	if err := json.Unmarshal([]byte(input), &v); err != nil {
 		return nil, err
 	}
@@ -301,34 +293,33 @@ func trimSuffix(suffix, s string) string {
 
 func newTemplate(name string) *template.Template {
 	tmpl := template.New(name).Funcs(template.FuncMap{
-		"closest":         arrayClosest,
-		"coalesce":        coalesce,
-		"contains":        contains,
-		"dict":            dict,
-		"dir":             dirList,
-		"exists":          exists,
-		"first":           arrayFirst,
-		"groupBy":         groupBy,
-		"groupByKeys":     groupByKeys,
-		"groupByMulti":    groupByMulti,
-		"hasPrefix":       hasPrefix,
-		"hasSuffix":       hasSuffix,
-		"json":            marshalJson,
-		"intersect":       intersect,
-		"keys":            keys,
-		"last":            arrayLast,
-		"replace":         strings.Replace,
-		"parseJsonArray":  unmarshalJsonArray,
-		"parseJsonObject": unmarshalJsonObject,
-		"sha1":            hashSha1,
-		"split":           strings.Split,
-		"trimPrefix":      trimPrefix,
-		"trimSuffix":      trimSuffix,
-		"where":           where,
-		"whereExist":      whereExist,
-		"whereNotExist":   whereNotExist,
-		"whereAny":        whereAny,
-		"whereAll":        whereAll,
+		"closest":       arrayClosest,
+		"coalesce":      coalesce,
+		"contains":      contains,
+		"dict":          dict,
+		"dir":           dirList,
+		"exists":        exists,
+		"first":         arrayFirst,
+		"groupBy":       groupBy,
+		"groupByKeys":   groupByKeys,
+		"groupByMulti":  groupByMulti,
+		"hasPrefix":     hasPrefix,
+		"hasSuffix":     hasSuffix,
+		"json":          marshalJson,
+		"intersect":     intersect,
+		"keys":          keys,
+		"last":          arrayLast,
+		"replace":       strings.Replace,
+		"parseJson":     unmarshalJson,
+		"sha1":          hashSha1,
+		"split":         strings.Split,
+		"trimPrefix":    trimPrefix,
+		"trimSuffix":    trimSuffix,
+		"where":         where,
+		"whereExist":    whereExist,
+		"whereNotExist": whereNotExist,
+		"whereAny":      whereAny,
+		"whereAll":      whereAll,
 	})
 	return tmpl
 }

--- a/template_test.go
+++ b/template_test.go
@@ -522,11 +522,15 @@ func TestJson(t *testing.T) {
 func TestParseJson(t *testing.T) {
 	tests := []struct {
 		tmpl     string
-		input    string
+		context  interface{}
 		expected string
 	}{
-		{`{{index (parseJson .) "enabled"}}`, `{"enabled":true}`, "true"},
-		{`{{index (parseJson . | first) "enabled"}}`, `[{"enabled":true}]`, "true"},
+		{`{{parseJson .}}`, `null`, `<no value>`},
+		{`{{parseJson .}}`, `true`, `true`},
+		{`{{parseJson .}}`, `1`, `1`},
+		{`{{parseJson .}}`, `0.5`, `0.5`},
+		{`{{index (parseJson .) "enabled"}}`, `{"enabled":true}`, `true`},
+		{`{{index (parseJson . | first) "enabled"}}`, `[{"enabled":true}]`, `true`},
 	}
 
 	for n, test := range tests {
@@ -534,7 +538,7 @@ func TestParseJson(t *testing.T) {
 		tmpl := template.Must(newTemplate(tmplName).Parse(test.tmpl))
 
 		var b bytes.Buffer
-		err := tmpl.ExecuteTemplate(&b, tmplName, test.input)
+		err := tmpl.ExecuteTemplate(&b, tmplName, test.context)
 		if err != nil {
 			t.Fatalf("Error executing template: %v", err)
 		}

--- a/template_test.go
+++ b/template_test.go
@@ -518,6 +518,44 @@ func TestJson(t *testing.T) {
 	}
 }
 
+func TestParseJsonArray(t *testing.T) {
+	const expected = "true"
+	const testJson = `[{"enabled":true}]`
+
+	const text = `{{index (parseJsonArray . | first) "enabled"}}`
+	tmpl := template.Must(newTemplate("parseJsonArray-test").Parse(text))
+
+	var b bytes.Buffer
+	err := tmpl.ExecuteTemplate(&b, "parseJsonArray-test", testJson)
+	if err != nil {
+		t.Fatalf("Error executing template: %v", err)
+	}
+
+	got := b.String()
+	if expected != got {
+		t.Fatalf("Incorrect output found; expected %s, got %s", expected, got)
+	}
+}
+
+func TestParseJsonObject(t *testing.T) {
+	const expected = "true"
+	const testJson = `{"enabled":true}`
+
+	const text = `{{index (parseJsonObject .) "enabled"}}`
+	tmpl := template.Must(newTemplate("parseJsonObject-test").Parse(text))
+
+	var b bytes.Buffer
+	err := tmpl.ExecuteTemplate(&b, "parseJsonObject-test", testJson)
+	if err != nil {
+		t.Fatalf("Error executing template: %v", err)
+	}
+
+	got := b.String()
+	if expected != got {
+		t.Fatalf("Incorrect output found; expected %s, got %s", expected, got)
+	}
+}
+
 func TestArrayClosestExact(t *testing.T) {
 	if arrayClosest([]string{"foo.bar.com", "bar.com"}, "foo.bar.com") != "foo.bar.com" {
 		t.Fatal("Expected foo.bar.com")

--- a/template_test.go
+++ b/template_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 	"text/template"
@@ -518,41 +519,30 @@ func TestJson(t *testing.T) {
 	}
 }
 
-func TestParseJsonArray(t *testing.T) {
-	const expected = "true"
-	const testJson = `[{"enabled":true}]`
-
-	const text = `{{index (parseJsonArray . | first) "enabled"}}`
-	tmpl := template.Must(newTemplate("parseJsonArray-test").Parse(text))
-
-	var b bytes.Buffer
-	err := tmpl.ExecuteTemplate(&b, "parseJsonArray-test", testJson)
-	if err != nil {
-		t.Fatalf("Error executing template: %v", err)
+func TestParseJson(t *testing.T) {
+	tests := []struct {
+		tmpl     string
+		input    string
+		expected string
+	}{
+		{`{{index (parseJson .) "enabled"}}`, `{"enabled":true}`, "true"},
+		{`{{index (parseJson . | first) "enabled"}}`, `[{"enabled":true}]`, "true"},
 	}
 
-	got := b.String()
-	if expected != got {
-		t.Fatalf("Incorrect output found; expected %s, got %s", expected, got)
-	}
-}
+	for n, test := range tests {
+		tmplName := fmt.Sprintf("parseJson-test-%d", n)
+		tmpl := template.Must(newTemplate(tmplName).Parse(test.tmpl))
 
-func TestParseJsonObject(t *testing.T) {
-	const expected = "true"
-	const testJson = `{"enabled":true}`
+		var b bytes.Buffer
+		err := tmpl.ExecuteTemplate(&b, tmplName, test.input)
+		if err != nil {
+			t.Fatalf("Error executing template: %v", err)
+		}
 
-	const text = `{{index (parseJsonObject .) "enabled"}}`
-	tmpl := template.Must(newTemplate("parseJsonObject-test").Parse(text))
-
-	var b bytes.Buffer
-	err := tmpl.ExecuteTemplate(&b, "parseJsonObject-test", testJson)
-	if err != nil {
-		t.Fatalf("Error executing template: %v", err)
-	}
-
-	got := b.String()
-	if expected != got {
-		t.Fatalf("Incorrect output found; expected %s, got %s", expected, got)
+		got := b.String()
+		if test.expected != got {
+			t.Fatalf("Incorrect output found; expected %s, got %s", test.expected, got)
+		}
 	}
 }
 

--- a/template_test.go
+++ b/template_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+	"text/template"
 )
 
 func TestContains(t *testing.T) {
@@ -27,20 +28,16 @@ func TestKeys(t *testing.T) {
 		expected: "demo.local",
 	}
 
-	k, err := keys(env)
+	const text = "{{range (keys $)}}{{.}}{{end}}"
+	tmpl := template.Must(newTemplate("keys-test").Parse(text))
+
+	var b bytes.Buffer
+	err := tmpl.ExecuteTemplate(&b, "keys-test", env)
 	if err != nil {
-		t.Fatalf("Error fetching keys: %v", err)
-	}
-	vk := reflect.ValueOf(k)
-	if vk.Kind() == reflect.Invalid {
-		t.Fatalf("Got invalid kind for keys: %v", vk)
+		t.Fatalf("Error executing template: %v", err)
 	}
 
-	if len(env) != vk.Len() {
-		t.Fatalf("Incorrect key count; expected %s, got %s", len(env), vk.Len())
-	}
-
-	got := vk.Index(0).Interface()
+	got := b.String()
 	if expected != got {
 		t.Fatalf("Incorrect key found; expected %s, got %s", expected, got)
 	}


### PR DESCRIPTION
Adds the `parseJsonArray` and `parseJsonObject` functions. Useful if the you have an environment variable like `MYCONFIG='{"enabled":true,"features":["foo","bar"]}'`. I was inspired by `INTERLOCK_CONFIG` in https://github.com/ehazlett/interlock

This includes the changes from #63.