### PR TITLE
Fix code for splitting KEY=VALUE env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ dist: dist-clean
 
 
 release: dist
-	glock sync github.com/jwilder/docker-gen
+	glock sync -n < GLOCKFILE
 	tar -cvzf docker-gen-linux-amd64-$(TAG).tar.gz -C dist/linux/amd64 docker-gen
 	tar -cvzf docker-gen-linux-i386-$(TAG).tar.gz -C dist/linux/i386 docker-gen
 	tar -cvzf docker-gen-linux-armel-$(TAG).tar.gz -C dist/linux/armel docker-gen

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .SILENT :
 .PHONY : docker-gen clean fmt
 
-TAG:=`git describe --abbrev=0 --tags`
+TAG:=`git describe --tags`
 LDFLAGS:=-X main.buildVersion $(TAG)
 
 all: docker-gen

--- a/docker-gen.go
+++ b/docker-gen.go
@@ -100,8 +100,11 @@ type Context []*RuntimeContainer
 func (c *Context) Env() map[string]string {
 
 	env := make(map[string]string)
-	for _, i := range os.Environ() {
-		parts := strings.Split(i, "=")
+	for _, entry := range os.Environ() {
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) != 2 {
+			parts = append(parts, "")
+		}
 		env[parts[0]] = parts[1]
 	}
 	return env

--- a/docker_client.go
+++ b/docker_client.go
@@ -148,7 +148,10 @@ func getContainers(client *docker.Client) ([]*RuntimeContainer, error) {
 		}
 
 		for _, entry := range container.Config.Env {
-			parts := strings.Split(entry, "=")
+			parts := strings.SplitN(entry, "=", 2)
+			if len(parts) != 2 {
+				parts = append(parts, "")
+			}
 			runtimeContainer.Env[parts[0]] = parts[1]
 		}
 


### PR DESCRIPTION
Make `docker-gen` work with env values with `=` in them as well as entries of the form `KEY` (no `=`)

As reported in jwilder/nginx-proxy#110 and zettio/weave#422