### PR TITLE
Optimize Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+docker-gen
+dist
+*.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,20 @@ FROM debian:wheezy
 MAINTAINER Jason Wilder <jwilder@litl.com>
 
 ENV VERSION 0.3.7
+ENV DOWNLOAD_URL https://github.com/jwilder/docker-gen/releases/download/$VERSION/docker-gen-linux-amd64-$VERSION.tar.gz
 ENV DOCKER_HOST unix:///tmp/docker.sock
 
-RUN apt-get update && apt-get install -y curl && curl -o docker-gen-linux-amd64-$VERSION.tar.gz -L https://github.com/jwilder/docker-gen/releases/download/$VERSION/docker-gen-linux-amd64-$VERSION.tar.gz && apt-get remove -y curl && apt-get -y clean
-RUN tar -C /usr/local/bin -xvzf docker-gen-linux-amd64-$VERSION.tar.gz && rm docker-gen-linux-amd64-$VERSION.tar.gz
+RUN deps=' \
+		curl ca-certificates \
+	'; \
+	set -x; \
+	apt-get update \
+	&& apt-get install -y --no-install-recommends $deps \
+	&& curl -o docker-gen.tar.gz -L $DOWNLOAD_URL \
+	&& tar -C /usr/local/bin -xvzf docker-gen.tar.gz \
+	&& rm docker-gen.tar.gz \
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $deps \
+	&& apt-get clean -y \
+	&& rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/usr/local/bin/docker-gen"]


### PR DESCRIPTION
I ended up looking at the Dockerfile for docker-gen after seeing this comment: https://github.com/jwilder/docker-gen/issues/50#issuecomment-70714517

I made the following improvements to help speed up and optimize the Docker image build:

* Remove and unpack TAR file in the same layer as the download
* Clean up more leftovers from installing curl
* Add .dockerignore to minimize build context to necessary files

I actually think that the `ENTRYPOINT` should be changed to a `CMD` too, but that would be a breaking change for some users and I didn't include it.