### PR TITLE
Expose QueryEscape from net/url as a template func

### DIFF
--- a/template.go
+++ b/template.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -311,6 +312,7 @@ func newTemplate(name string) *template.Template {
 		"last":          arrayLast,
 		"replace":       strings.Replace,
 		"parseJson":     unmarshalJson,
+		"queryEscape":   url.QueryEscape,
 		"sha1":          hashSha1,
 		"split":         strings.Split,
 		"trimPrefix":    trimPrefix,

--- a/template_test.go
+++ b/template_test.go
@@ -550,6 +550,35 @@ func TestParseJson(t *testing.T) {
 	}
 }
 
+func TestQueryEscape(t *testing.T) {
+	tests := []struct {
+		tmpl     string
+		context  interface{}
+		expected string
+	}{
+		{`{{queryEscape .}}`, `example.com`, `example.com`},
+		{`{{queryEscape .}}`, `.example.com`, `.example.com`},
+		{`{{queryEscape .}}`, `*.example.com`, `%2A.example.com`},
+		{`{{queryEscape .}}`, `~^example\.com(\..*\.xip\.io)?$`, `~%5Eexample%5C.com%28%5C..%2A%5C.xip%5C.io%29%3F%24`},
+	}
+
+	for n, test := range tests {
+		tmplName := fmt.Sprintf("queryEscape-test-%d", n)
+		tmpl := template.Must(newTemplate(tmplName).Parse(test.tmpl))
+
+		var b bytes.Buffer
+		err := tmpl.ExecuteTemplate(&b, tmplName, test.context)
+		if err != nil {
+			t.Fatalf("Error executing template: %v", err)
+		}
+
+		got := b.String()
+		if test.expected != got {
+			t.Fatalf("Incorrect output found; expected %s, got %s", test.expected, got)
+		}
+	}
+}
+
 func TestArrayClosestExact(t *testing.T) {
 	if arrayClosest([]string{"foo.bar.com", "bar.com"}, "foo.bar.com") != "foo.bar.com" {
 		t.Fatal("Expected foo.bar.com")


### PR DESCRIPTION
This exposes the `QueryEscape(string) string` function from `net/url` as `queryEscape`. I think this can be used to easily fix https://github.com/jwilder/nginx-proxy/issues/117