### PR TITLE
Set host IP on container addresses

### DIFF
--- a/docker-gen.go
+++ b/docker-gen.go
@@ -44,6 +44,7 @@ type Address struct {
 	IP       string
 	Port     string
 	HostPort string
+	HostIP   string
 	Proto    string
 }
 

--- a/docker_client.go
+++ b/docker_client.go
@@ -135,6 +135,7 @@ func getContainers(client *docker.Client) ([]*RuntimeContainer, error) {
 			}
 			if len(v) > 0 {
 				address.HostPort = v[0].HostPort
+				address.HostIP = v[0].HostIP
 			}
 			runtimeContainer.Addresses = append(runtimeContainer.Addresses,
 				address)


### PR DESCRIPTION
This is especially useful when using docker-gen with swarm.

Could also use the new Node object but this felt simpler.