### PR TITLE
Always expose container address

### DIFF
--- a/docker-gen.go
+++ b/docker-gen.go
@@ -47,6 +47,7 @@ type Address struct {
 	Port     string
 	HostPort string
 	Proto    string
+	HostIP   string
 }
 
 type Volume struct {
@@ -65,6 +66,7 @@ type RuntimeContainer struct {
 	Volumes   map[string]Volume
 	Node      SwarmNode
 	Labels    map[string]string
+	IP        string
 }
 
 type DockerImage struct {

--- a/docker_client.go
+++ b/docker_client.go
@@ -127,6 +127,7 @@ func getContainers(client *docker.Client) ([]*RuntimeContainer, error) {
 			Volumes:   make(map[string]Volume),
 			Node:      SwarmNode{},
 			Labels:    make(map[string]string),
+			IP:        container.NetworkSettings.IPAddress,
 		}
 		for k, v := range container.NetworkSettings.Ports {
 			address := Address{
@@ -136,6 +137,7 @@ func getContainers(client *docker.Client) ([]*RuntimeContainer, error) {
 			}
 			if len(v) > 0 {
 				address.HostPort = v[0].HostPort
+				address.HostIP = v[0].HostIP
 			}
 			runtimeContainer.Addresses = append(runtimeContainer.Addresses,
 				address)


### PR DESCRIPTION
Previously, it was not possible to determine the IP address of a container without any EXPOSEd ports.

I also threw in a change to expose `HostIP` on the `Address` struct in addition to `HostPort`.

Fixes #79 