### PR TITLE
fix an incorrect docker-gen parameter in example, other minor fixes and 1 proposed change to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Fetch the template and start the docker-gen container with the shared volume:
 $ mkdir -p /tmp/templates && cd /tmp/templates
 $ curl -o nginx.tmpl https://raw.githubusercontent.com/jwilder/docker-gen/master/templates/nginx.tmpl
 $ docker run -d --name nginx-gen --volumes-from nginx \
-   -v /var/run/docker.sock:/tmp/docker.sock \
+   -v /var/run/docker.sock:/tmp/docker.sock:ro \
    -v /tmp/templates:/etc/docker-gen/templates \
-   -t jwilder/docker-gen:0.3.4 -notify-sighup nginx -watch --only-published /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
+   -t jwilder/docker-gen -notify-sighup nginx -watch -only-exposed /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
 ```
 
 ===


### PR DESCRIPTION
- Needed to fix the incorrect --only-published to -only-published 
- Proposed change: I think it's more likely to work for more people if change -only-published to -only-exposed
- added :ro to the sock, to match your other examples in your other project pages.