### PR TITLE
Add support for docker 1.8 Mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:wheezy
 MAINTAINER Jason Wilder <jason@influxdb.com>
 
-ENV VERSION 0.5.0
+ENV VERSION 0.5.1
 ENV DOWNLOAD_URL https://github.com/jwilder/docker-gen/releases/download/$VERSION/docker-gen-linux-amd64-$VERSION.tar.gz
 ENV DOCKER_HOST unix:///tmp/docker.sock
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
 FROM debian:wheezy
 MAINTAINER Jason Wilder <jason@influxdb.com>
 
-ENV VERSION 0.4.1
+ENV VERSION 0.5.0
 ENV DOWNLOAD_URL https://github.com/jwilder/docker-gen/releases/download/$VERSION/docker-gen-linux-amd64-$VERSION.tar.gz
 ENV DOCKER_HOST unix:///tmp/docker.sock
 
 RUN deps=' \
-		curl ca-certificates \
-	'; \
-	set -x; \
-	apt-get update \
-	&& apt-get install -y --no-install-recommends $deps \
-	&& curl -o docker-gen.tar.gz -L $DOWNLOAD_URL \
-	&& tar -C /usr/local/bin -xvzf docker-gen.tar.gz \
-	&& rm docker-gen.tar.gz \
-	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $deps \
-	&& apt-get clean -y \
-	&& rm -rf /var/lib/apt/lists/*
+                curl ca-certificates \
+        '; \
+        set -x; \
+        apt-get update \
+        && apt-get install -y --no-install-recommends $deps \
+        && curl -o docker-gen.tar.gz -L $DOWNLOAD_URL \
+        && tar -C /usr/local/bin -xvzf docker-gen.tar.gz \
+        && rm docker-gen.tar.gz \
+        && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $deps \
+        && apt-get clean -y \
+        && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/usr/local/bin/docker-gen"]

--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,4 +1,4 @@
 github.com/BurntSushi/toml f87ce853111478914f0bcffa34d43a93643e6eda
 github.com/Sirupsen/logrus 6ebb4e7b3c24b9fef150d7693e728cb1ebadf1f5
-github.com/docker/docker 95dcb2748442fc1f59e8c2e010679e0aea3cef1c
-github.com/fsouza/go-dockerclient 1e60afa8d58b91a0eca0a732927c8ecba696493f
+github.com/docker/docker 11a9c4550c2036c8b69c0a523870dc54a972506b
+github.com/fsouza/go-dockerclient c9ad0ce23f68428421adfc6ced9e6123f54788a5

--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,4 +1,4 @@
 github.com/BurntSushi/toml f87ce853111478914f0bcffa34d43a93643e6eda
 github.com/Sirupsen/logrus 6ebb4e7b3c24b9fef150d7693e728cb1ebadf1f5
-github.com/docker/docker 11a9c4550c2036c8b69c0a523870dc54a972506b
+github.com/docker/docker 0a8c2e3717cb3a6fe4e8cb10243cb06473052541
 github.com/fsouza/go-dockerclient c9ad0ce23f68428421adfc6ced9e6123f54788a5

--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,4 +1,4 @@
-github.com/BurntSushi/toml f87ce853111478914f0bcffa34d43a93643e6eda
-github.com/Sirupsen/logrus 6ebb4e7b3c24b9fef150d7693e728cb1ebadf1f5
-github.com/docker/docker 0a8c2e3717cb3a6fe4e8cb10243cb06473052541
-github.com/fsouza/go-dockerclient c9ad0ce23f68428421adfc6ced9e6123f54788a5
+github.com/BurntSushi/toml 056c9bc7be7190eaa7715723883caffa5f8fa3e4
+github.com/Sirupsen/logrus 446d1c146faa8ed3f4218f056fcd165f6bcfda81
+github.com/docker/docker e7e3e568d12ea7b1759a311ed3ef722ed187bcec
+github.com/fsouza/go-dockerclient e0d22d30691bcc996eca51f729a4777b8c7dc2a8

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY : docker-gen clean fmt
 
 TAG:=`git describe --tags`
-LDFLAGS:=-X main.buildVersion $(TAG)
+LDFLAGS:=-X main.buildVersion=$(TAG)
 
 all: docker-gen
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 docker-gen
 =====
 
-![latest v0.4.1](https://img.shields.io/badge/latest-v0.4.1-green.svg?style=flat)
+![latest v0.5.1](https://img.shields.io/badge/latest-v0.5.1-green.svg?style=flat)
 [![Build Status](https://travis-ci.org/jwilder/docker-gen.svg?branch=master)](https://travis-ci.org/jwilder/docker-gen)
 ![License MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)
 
@@ -25,16 +25,16 @@ There are three common ways to run docker-gen:
 
 #### Host Install
 
-Linux/OSX binaries for release [0.4.1](https://github.com/jwilder/docker-gen/releases)
+Linux/OSX binaries for release [0.5.1](https://github.com/cybercode/docker-gen/releases)
 
-* [amd64](https://github.com/jwilder/docker-gen/releases/download/0.4.1/docker-gen-linux-amd64-0.4.1.tar.gz)
-* [i386](https://github.com/jwilder/docker-gen/releases/download/0.4.1/docker-gen-linux-i386-0.4.1.tar.gz)
+* [amd64](https://github.com/cybercode/docker-gen/releases/download/0.5.1/docker-gen-linux-amd64-0.5.1.tar.gz)
+* [i386](https://github.com/cybercode/docker-gen/releases/download/0.5.1/docker-gen-linux-i386-0.5.1.tar.gz)
 
 Download the version you need, untar, and install to your PATH.
 
 ```
-$ wget https://github.com/jwilder/docker-gen/releases/download/0.4.1/docker-gen-linux-amd64-0.4.1.tar.gz
-$ tar xvzf docker-gen-linux-amd64-0.4.1.tar.gz
+$ wget https://github.com/cybercode/docker-gen/releases/download/0.5.1/docker-gen-linux-amd64-0.5.1.tar.gz
+$ tar xvzf docker-gen-linux-amd64-0.5.1.tar.gz
 $ ./docker-gen
 ```
 
@@ -42,14 +42,14 @@ $ ./docker-gen
 
 Docker-gen can be bundled inside of a container along-side applications.
 
-[jwilder/nginx-proxy](https://index.docker.io/u/jwilder/nginx-proxy/) trusted build is an example of
+[cybercode/nginx-proxy](https://index.docker.io/u/cybercode/nginx-proxy/) trusted build is an example of
 running docker-gen within a container along-side nginx.
-[jwilder/docker-register](https://github.com/jwilder/docker-register) is an example of running
+[cybercode/docker-register](https://github.com/cybercode/docker-register) is an example of running
 docker-gen within a container to do service registration with etcd.
 
 #### Separate Container Install
 
-It can also be run as two separate containers using the [jwilder/docker-gen](https://index.docker.io/u/jwilder/docker-gen/)
+It can also be run as two separate containers using the [cybercode/docker-gen](https://index.docker.io/u/cybercode/docker-gen/)
 image virtually any other image.
 
 This is how you could run the official [nginx](https://registry.hub.docker.com/_/nginx/) image and
@@ -65,11 +65,11 @@ $ docker run -d -p 80:80 --name nginx -v /tmp/nginx:/etc/nginx/conf.d -t nginx
 Fetch the template and start the docker-gen container with the shared volume:
 ```
 $ mkdir -p /tmp/templates && cd /tmp/templates
-$ curl -o nginx.tmpl https://raw.githubusercontent.com/jwilder/docker-gen/master/templates/nginx.tmpl
+$ curl -o nginx.tmpl https://raw.githubusercontent.com/cybercode/docker-gen/master/templates/nginx.tmpl
 $ docker run -d --name nginx-gen --volumes-from nginx \
    -v /var/run/docker.sock:/tmp/docker.sock:ro \
    -v /tmp/templates:/etc/docker-gen/templates \
-   -t jwilder/docker-gen -notify-sighup nginx -watch -only-exposed /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
+   -t cybercode/docker-gen -notify-sighup nginx -watch -only-exposed /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
 ```
 
 ===
@@ -186,7 +186,7 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
    "Name":"docker_register",
    "Hostname":"71e976807583",
    "Image":{
-      "Registry":"jwilder",
+      "Registry":"cybercode",
       "Repository":"docker-register"
    },
    "Env":{
@@ -244,12 +244,12 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
 
 #### NGINX Reverse Proxy Config
 
-[jwilder/nginx-proxy](https://index.docker.io/u/jwilder/nginx-proxy/) trusted build.
+[cybercode/nginx-proxy](https://index.docker.io/u/cybercode/nginx-proxy/) trusted build.
 
 Start nginx-proxy:
 
 ```
-$ docker run -d -p 80:80 -v /var/run/docker.sock:/tmp/docker.sock -t jwilder/nginx-proxy
+$ docker run -d -p 80:80 -v /var/run/docker.sock:/tmp/docker.sock -t cybercode/nginx-proxy
 ```
 
 Then start containers with a VIRTUAL_HOST env variable:
@@ -291,7 +291,7 @@ You'll need to install glock into your workspace before hacking on docker-gen.
 
 ```
 $ git clone <your fork>
-$ glock sync github.com/jwilder/docker-gen
+$ glock sync github.com/cybercode/docker-gen
 $ make
 ```
 

--- a/docker_client.go
+++ b/docker_client.go
@@ -151,6 +151,13 @@ func getContainers(client *docker.Client) ([]*RuntimeContainer, error) {
 				ReadWrite: container.VolumesRW[k],
 			}
 		}
+		for _, v := range container.Mounts {
+			runtimeContainer.Volumes[v.Destination] = Volume{
+				HostPath:  v.Source,
+				Path:      v.Destination,
+				ReadWrite: v.RW,
+			}
+		}
 		if container.Node != nil {
 			runtimeContainer.Node.ID = container.Node.ID
 			runtimeContainer.Node.Name = container.Node.Name


### PR DESCRIPTION
This patch uses the current `Volumes` map instead of creating a new `Mounts` map. This should make the underlying API changes transparent to docker-gen users.