### PR TITLE
strip www from host names

### DIFF
--- a/templates/nginx.tmpl
+++ b/templates/nginx.tmpl
@@ -40,6 +40,12 @@ upstream {{ $host }} {
 {{ end }}
 }
 
+# strip www from any host names which begin with it
+server {                                                                                                                                                
+    server_name www.{{ $host }};                                                                                                                        
+    return 301 $scheme://{{ $host }}$request_uri;                                                                                                       
+}
+
 server {
 	gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 


### PR DESCRIPTION
If a host name begins with "www." strip it off and redirect to the naked host name.

I don't know if you want to add this to your code, but I find it helpful as I have both www.example.com and example.com coming in to be handled by nginx and sent to containers. But I prefer all users get redirected to see just the example.com URL in their browsers.