### PR TITLE
added ipv6 support

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,4 +1,4 @@
 github.com/BurntSushi/toml f87ce853111478914f0bcffa34d43a93643e6eda
 github.com/Sirupsen/logrus 6ebb4e7b3c24b9fef150d7693e728cb1ebadf1f5
-github.com/docker/docker 95dcb2748442fc1f59e8c2e010679e0aea3cef1c
-github.com/fsouza/go-dockerclient 1e60afa8d58b91a0eca0a732927c8ecba696493f
+github.com/docker/docker 2606a2e4d3bf810ec82e373a6cd334e22e504e83
+github.com/fsouza/go-dockerclient 1399676f53e6ccf46e0bf00751b21bed329bc60e

--- a/docker-gen.go
+++ b/docker-gen.go
@@ -47,8 +47,8 @@ type Event struct {
 
 type Address struct {
 	IP            string
-	IP6_LinkLocal string
-	IP6_Global    string
+	IP6LinkLocal  string
+	IP6Global     string
 	Port          string
 	HostPort      string
 	Proto         string
@@ -73,8 +73,8 @@ type RuntimeContainer struct {
 	Node          SwarmNode
 	Labels        map[string]string
 	IP            string
-	IP6_LinkLocal string
-	IP6_Global    string
+	IP6LinkLocal  string
+	IP6Global     string
 }
 
 type DockerImage struct {

--- a/docker-gen.go
+++ b/docker-gen.go
@@ -46,11 +46,13 @@ type Event struct {
 }
 
 type Address struct {
-	IP       string
-	Port     string
-	HostPort string
-	Proto    string
-	HostIP   string
+	IP            string
+	IP6_LinkLocal string
+	IP6_Global    string
+	Port          string
+	HostPort      string
+	Proto         string
+	HostIP        string
 }
 
 type Volume struct {
@@ -60,17 +62,19 @@ type Volume struct {
 }
 
 type RuntimeContainer struct {
-	ID        string
-	Addresses []Address
-	Gateway   string
-	Name      string
-	Hostname  string
-	Image     DockerImage
-	Env       map[string]string
-	Volumes   map[string]Volume
-	Node      SwarmNode
-	Labels    map[string]string
-	IP        string
+	ID            string
+	Addresses     []Address
+	Gateway       string
+	Name          string
+	Hostname      string
+	Image         DockerImage
+	Env           map[string]string
+	Volumes       map[string]Volume
+	Node          SwarmNode
+	Labels        map[string]string
+	IP            string
+	IP6_LinkLocal string
+	IP6_Global    string
 }
 
 type DockerImage struct {

--- a/docker_client.go
+++ b/docker_client.go
@@ -129,14 +129,14 @@ func getContainers(client *docker.Client) ([]*RuntimeContainer, error) {
 			Node:      SwarmNode{},
 			Labels:    make(map[string]string),
 			IP:        container.NetworkSettings.IPAddress,
-			IP6_LinkLocal:        container.NetworkSettings.LinkLocalIPv6Address,
-			IP6_Global:        container.NetworkSettings.GlobalIPv6Address,
+			IP6LinkLocal:        container.NetworkSettings.LinkLocalIPv6Address,
+			IP6Global:        container.NetworkSettings.GlobalIPv6Address,
 		}
 		for k, v := range container.NetworkSettings.Ports {
 			address := Address{
 				IP:    container.NetworkSettings.IPAddress,
-				IP6_LinkLocal:        container.NetworkSettings.LinkLocalIPv6Address,
-				IP6_Global:        container.NetworkSettings.GlobalIPv6Address,
+				IP6LinkLocal:        container.NetworkSettings.LinkLocalIPv6Address,
+				IP6Global:        container.NetworkSettings.GlobalIPv6Address,
 				Port:  k.Port(),
 				Proto: k.Proto(),
 			}

--- a/docker_client.go
+++ b/docker_client.go
@@ -129,10 +129,14 @@ func getContainers(client *docker.Client) ([]*RuntimeContainer, error) {
 			Node:      SwarmNode{},
 			Labels:    make(map[string]string),
 			IP:        container.NetworkSettings.IPAddress,
+			IP6_LinkLocal:        container.NetworkSettings.LinkLocalIPv6Address,
+			IP6_Global:        container.NetworkSettings.GlobalIPv6Address,
 		}
 		for k, v := range container.NetworkSettings.Ports {
 			address := Address{
 				IP:    container.NetworkSettings.IPAddress,
+				IP6_LinkLocal:        container.NetworkSettings.LinkLocalIPv6Address,
+				IP6_Global:        container.NetworkSettings.GlobalIPv6Address,
 				Port:  k.Port(),
 				Proto: k.Proto(),
 			}


### PR DESCRIPTION
These changes add IPv6 support to docker-gen.

IPv6 addresses of docker containers are available as `IP6_LinkLocal` and `IP6_Global` next to the old `IP` string.

I had to update the used docker client library to a newer version with support for `container.NetworkSettings.LinkLocalIPv6Address` and `container.NetworkSettings.GlobalIPv6Address`