### PR TITLE
VERSION 0.4.2 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:wheezy
 MAINTAINER Jason Wilder <jason@influxdb.com>
 
-ENV VERSION 0.4.1
+ENV VERSION 0.4.2
 ENV DOWNLOAD_URL https://github.com/jwilder/docker-gen/releases/download/$VERSION/docker-gen-linux-amd64-$VERSION.tar.gz
 ENV DOCKER_HOST unix:///tmp/docker.sock
 


### PR DESCRIPTION
As per issue #124, the version number was not incremented in the Dockerfile for that release