### PR TITLE
Add server info

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,17 +135,20 @@ Within the templates, the object emitted by docker-gen will be a structure consi
 
 ```go
 type RuntimeContainer struct {
-    ID        string
-    Addresses []Address
-    Gateway   string
-    Name      string
-    Hostname  string
-    Image     DockerImage
-    Env       map[string]string
-    Volumes   map[string]Volume
-    Node      SwarmNode
-    Labels    map[string]string
-    IP        string
+	ID           string
+	Addresses    []Address
+	Gateway      string
+	Name         string
+	Hostname     string
+	Image        DockerImage
+	Env          map[string]string
+	Volumes      map[string]Volume
+	Node         SwarmNode
+	Labels       map[string]string
+	Server       ServerInfo
+	IP           string
+	IP6LinkLocal string
+	IP6Global    string
 }
 
 type Address struct {
@@ -172,6 +175,21 @@ type SwarmNode struct {
     ID      string
     Name    string
     Address Address
+}
+
+type ServerInfo struct {
+	Name          string
+	NumContainers int
+	NumImages     int
+	DockerInfo    DockerInfo
+}
+
+type DockerInfo struct {
+	Version         string
+	ApiVersion      string
+	GoVersion       string
+	OperatingSystem string
+	Architecture    string
 }
 ```
 

--- a/docker-gen.go
+++ b/docker-gen.go
@@ -72,6 +72,7 @@ type RuntimeContainer struct {
 	Volumes      map[string]Volume
 	Node         SwarmNode
 	Labels       map[string]string
+	Server       ServerInfo
 	IP           string
 	IP6LinkLocal string
 	IP6Global    string
@@ -87,6 +88,21 @@ type SwarmNode struct {
 	ID      string
 	Name    string
 	Address Address
+}
+
+type ServerInfo struct {
+	Name          string
+	NumContainers int
+	NumImages     int
+	DockerInfo    DockerInfo
+}
+
+type DockerInfo struct {
+	Version         string
+	ApiVersion      string
+	GoVersion       string
+	OperatingSystem string
+	Architecture    string
 }
 
 func (strings *stringslice) String() string {


### PR DESCRIPTION
Uses the info and version commands to get various info about the docker server.

My use-case for this is forwarding a lot of information to logstash from various clusters and wanting to be able to track down the server that the log entry is coming from quickly. Since fleet can deploy containers to different servers based on rules and availability, getting the hostname that the container lives on is vital.

I've also updated the structs in the README to match what's currently in the code.

Let me know if you have any questions/changes/etc.

Thanks!
Ted