### PR TITLE
include stopped containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Options:
       only include containers with exposed ports
   -only-published
       only include containers with published ports (implies -only-exposed)
+  -include-stopped
+      include stopped containers
   -tlscacert string
       path to TLS CA certificate file (default "/Users/jason/.docker/machine/machines/default/ca.pem")
   -tlscert string
@@ -213,6 +215,7 @@ type RuntimeContainer struct {
     IP6LinkLocal string
     IP6Global    string
     Mounts       []Mount
+    State        State
 }
 
 type Address struct {
@@ -262,6 +265,10 @@ type SwarmNode struct {
     ID      string
     Name    string
     Address Address
+}
+
+type State struct {
+  Running bool
 }
 
 // Accessible from the root in templates as .Docker

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -24,6 +24,7 @@ var (
 	notifySigHUPContainerID string
 	onlyExposed             bool
 	onlyPublished           bool
+	includeStopped          bool
 	configFiles             stringslice
 	configs                 dockergen.ConfigFile
 	interval                int
@@ -89,6 +90,7 @@ func initFlags() {
 
 	flag.BoolVar(&onlyPublished, "only-published", false,
 		"only include containers with published ports (implies -only-exposed)")
+	flag.BoolVar(&includeStopped, "include-stopped", false, "include stopped containers")
 	flag.BoolVar(&notifyOutput, "notify-output", false, "log the output(stdout/stderr) of notify command")
 	flag.StringVar(&notifyCmd, "notify", "", "run command after template is regenerated (e.g `restart xyz`)")
 	flag.StringVar(&notifySigHUPContainerID, "notify-sighup", "",
@@ -136,6 +138,7 @@ func main() {
 			NotifyContainers: make(map[string]docker.Signal),
 			OnlyExposed:      onlyExposed,
 			OnlyPublished:    onlyPublished,
+			IncludeStopped:   includeStopped,
 			Interval:         interval,
 			KeepBlankLines:   keepBlankLines,
 		}
@@ -146,12 +149,20 @@ func main() {
 			Config: []dockergen.Config{config}}
 	}
 
+	all := true
+	for _, config := range configs.Config {
+		if config.IncludeStopped {
+			all = true
+		}
+	}
+
 	generator, err := dockergen.NewGenerator(dockergen.GeneratorConfig{
 		Endpoint:   endpoint,
 		TLSKey:     tlsKey,
 		TLSCert:    tlsCert,
 		TLSCACert:  tlsCaCert,
 		TLSVerify:  tlsVerify,
+		All:        all,
 		ConfigFile: configs,
 	})
 

--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	NotifyContainers map[string]docker.Signal
 	OnlyExposed      bool
 	OnlyPublished    bool
+	IncludeStopped   bool
 	Interval         int
 	KeepBlankLines   bool
 }

--- a/context.go
+++ b/context.go
@@ -74,6 +74,10 @@ type Volume struct {
 	ReadWrite bool
 }
 
+type State struct {
+	Running bool
+}
+
 type RuntimeContainer struct {
 	ID           string
 	Addresses    []Address
@@ -90,6 +94,7 @@ type RuntimeContainer struct {
 	IP6LinkLocal string
 	IP6Global    string
 	Mounts       []Mount
+	State        State
 }
 
 func (r *RuntimeContainer) Equals(o RuntimeContainer) bool {

--- a/generator.go
+++ b/generator.go
@@ -20,6 +20,7 @@ type generator struct {
 	Endpoint                   string
 	TLSVerify                  bool
 	TLSCert, TLSCaCert, TLSKey string
+	All                        bool
 
 	wg sync.WaitGroup
 }
@@ -31,6 +32,7 @@ type GeneratorConfig struct {
 	TLSKey    string
 	TLSCACert string
 	TLSVerify bool
+	All       bool
 
 	ConfigFile ConfigFile
 }
@@ -61,6 +63,7 @@ func NewGenerator(gc GeneratorConfig) (*generator, error) {
 		TLSCert:   gc.TLSCert,
 		TLSCaCert: gc.TLSCACert,
 		TLSKey:    gc.TLSKey,
+		All:       gc.All,
 		Configs:   gc.ConfigFile,
 	}, nil
 }
@@ -280,7 +283,7 @@ func (g *generator) getContainers() ([]*RuntimeContainer, error) {
 	SetServerInfo(apiInfo)
 
 	apiContainers, err := g.Client.ListContainers(docker.ListContainersOptions{
-		All:  false,
+		All:  g.All,
 		Size: false,
 	})
 	if err != nil {
@@ -302,6 +305,9 @@ func (g *generator) getContainers() ([]*RuntimeContainer, error) {
 				Registry:   registry,
 				Repository: repository,
 				Tag:        tag,
+			},
+			State: State{
+				Running: container.State.Running,
 			},
 			Name:         strings.TrimLeft(container.Name, "/"),
 			Hostname:     container.Config.Hostname,

--- a/template.go
+++ b/template.go
@@ -233,7 +233,7 @@ func keys(input interface{}) (interface{}, error) {
 
 	vk := val.MapKeys()
 	k := make([]interface{}, val.Len())
-	for i, _ := range k {
+	for i := range k {
 		k[i] = vk[i].Interface()
 	}
 
@@ -425,22 +425,37 @@ func newTemplate(name string) *template.Template {
 	return tmpl
 }
 
+func filterRunning(config Config, containers Context) Context {
+	if config.IncludeStopped {
+		return containers
+	} else {
+		filteredContainers := Context{}
+		for _, container := range containers {
+			if container.State.Running {
+				filteredContainers = append(filteredContainers, container)
+			}
+		}
+		return filteredContainers
+	}
+}
+
 func GenerateFile(config Config, containers Context) bool {
+	filteredRunningContainers := filterRunning(config, containers)
 	filteredContainers := Context{}
 	if config.OnlyPublished {
-		for _, container := range containers {
+		for _, container := range filteredRunningContainers {
 			if len(container.PublishedAddresses()) > 0 {
 				filteredContainers = append(filteredContainers, container)
 			}
 		}
 	} else if config.OnlyExposed {
-		for _, container := range containers {
+		for _, container := range filteredRunningContainers {
 			if len(container.Addresses) > 0 {
 				filteredContainers = append(filteredContainers, container)
 			}
 		}
 	} else {
-		filteredContainers = containers
+		filteredContainers = filteredRunningContainers
 	}
 
 	contents := executeTemplate(config.Template, filteredContainers)


### PR DESCRIPTION
It may be interesting to see stopped containers.
For example, my use case was to expose volumes mount points to nginx, that contains the results of a dockerized script.