### PR TITLE
add template example for dnsmasq hosts list

### DIFF
--- a/templates/dnsmasq.hosts.conf.tmpl
+++ b/templates/dnsmasq.hosts.conf.tmpl
@@ -1,0 +1,7 @@
+{{$domain := "docker.company.com"}}
+{{range $key, $value := .}}
+# {{ $value.Name }} ({{$value.ID}} from {{$value.Image.Repository}})
+{{$value.IP}}   {{ $value.Name }}.{{$domain}}
+{{$value.IP6Global}}    {{ $value.Name }}.{{$domain}}
+
+{{end}}


### PR DESCRIPTION
Can be useful here: https://blog.amartynov.ru/archives/dnsmasq-docker-service-discovery/
Or with this image: https://github.com/andyshinn/docker-dnsmasq

(just point `dnsmasq.conf` to load generated hosts file with `addn-hosts=/etc/dnsmasq/hosts/docker.hosts.conf`)

solution with dnsmasq (and ipv6 addresses) can be workaround for issue: https://github.com/docker/docker/issues/13228 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jwilder/docker-gen/140)
<!-- Reviewable:end -->
