### PR TITLE
Add notify output

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Options:
       keep blank lines in the output file
   -notify restart xyz
       run command after template is regenerated (e.g restart xyz)
+  -notify-output
+      log the output(stdout/stderr) of notify command
   -notify-sighup docker kill -s HUP container-ID
       send HUP signal to container.  Equivalent to docker kill -s HUP container-ID
   -only-exposed

--- a/docker-gen.go
+++ b/docker-gen.go
@@ -23,6 +23,7 @@ var (
 	version                 bool
 	watch                   bool
 	notifyCmd               string
+	notifyOutput            bool
 	notifySigHUPContainerID string
 	onlyExposed             bool
 	onlyPublished           bool
@@ -115,6 +116,7 @@ type Config struct {
 	Dest             string
 	Watch            bool
 	NotifyCmd        string
+	NotifyOutput     bool
 	NotifyContainers map[string]docker.Signal
 	OnlyExposed      bool
 	OnlyPublished    bool
@@ -232,7 +234,13 @@ func runNotifyCmd(config Config) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Printf("Error running notify command: %s, %s\n", config.NotifyCmd, err)
-		log.Print(string(out))
+	}
+	if config.NotifyOutput {
+		for _, line := range strings.Split(string(out), "\n") {
+			if line != "" {
+				log.Printf("[%s]: %s", config.NotifyCmd, line)
+			}
+		}
 	}
 }
 
@@ -393,6 +401,7 @@ func initFlags() {
 
 	flag.BoolVar(&onlyPublished, "only-published", false,
 		"only include containers with published ports (implies -only-exposed)")
+	flag.BoolVar(&notifyOutput, "notify-output", false, "log the output(stdout/stderr) of notify command")
 	flag.StringVar(&notifyCmd, "notify", "", "run command after template is regenerated (e.g `restart xyz`)")
 	flag.StringVar(&notifySigHUPContainerID, "notify-sighup", "",
 		"send HUP signal to container.  Equivalent to `docker kill -s HUP container-ID`")
@@ -435,6 +444,7 @@ func main() {
 			Dest:             flag.Arg(1),
 			Watch:            watch,
 			NotifyCmd:        notifyCmd,
+			NotifyOutput:     notifyOutput,
 			NotifyContainers: make(map[string]docker.Signal),
 			OnlyExposed:      onlyExposed,
 			OnlyPublished:    onlyPublished,


### PR DESCRIPTION
Adds option to forward any output from the notify command to the logstream of docker-gen.  Resolves https://github.com/jwilder/docker-gen/issues/75