### PR TITLE
Add whereLabel* functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,12 +310,15 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
 * *`trimPrefix $prefix $string`*: If `$prefix` is a prefix of `$string`, return `$string` with `$prefix` trimmed from the beginning. Otherwise, return `$string` unchanged.
 * *`trimSuffix $suffix $string`*: If `$suffix` is a suffix of `$string`, return `$string` with `$suffix` trimmed from the end. Otherwise, return `$string` unchanged.
 * *`trim $string`*: Removes whitespace from both sides of `$string`.
+* *`when $condition $trueValue $falseValue`*: Returns the `$trueValue` when the `$condition` is `true` and the `$falseValue` otherwise
 * *`where $items $fieldPath $value`*: Filters an array or slice based on the values of a field path expression `$fieldPath`. A field path expression is a dot-delimited list of map keys or struct member names specifying the path from container to a nested value. Returns an array of items having that value.
 * *`whereExist $items $fieldPath`*: Like `where`, but returns only items where `$fieldPath` exists (is not nil).
 * *`whereNotExist $items $fieldPath`*: Like `where`, but returns only items where `$fieldPath` does not exist (is nil).
 * *`whereAny $items $fieldPath $sep $values`*: Like `where`, but the string value specified by `$fieldPath` is first split by `$sep` into a list of strings. The comparison value is a string slice with possible matches. Returns items which OR intersect these values.
 * *`whereAll $items $fieldPath $sep $values`*: Like `whereAny`, except all `$values` must exist in the `$fieldPath`.
-* *`when $condition $trueValue $falseValue`*: Returns the `$trueValue` when the `$condition` is `true` and the `$falseValue` otherwise
+* *`whereLabelExists $containers $label`*: Filters a slice of containers based on the existence of the label `$label`.
+* *`whereLabelDoesNotExist $containers $label`*: Filters a slice of containers based on the non-existence of the label `$label`.
+* *`whereLabelValueMatches $containers $label $pattern`*: Filters a slice of containers based on the existence of the label `$label` with values matching the regular expression `$pattern`.
 
 ===
 

--- a/template_test.go
+++ b/template_test.go
@@ -452,6 +452,87 @@ func TestWhereRequires(t *testing.T) {
 	tests.run(t, "whereAll")
 }
 
+func TestWhereLabelExists(t *testing.T) {
+	containers := []*RuntimeContainer{
+		&RuntimeContainer{
+			Labels: map[string]string{
+				"com.example.foo": "foo",
+				"com.example.bar": "bar",
+			},
+			ID: "1",
+		},
+		&RuntimeContainer{
+			Labels: map[string]string{
+				"com.example.bar": "bar",
+			},
+			ID: "2",
+		},
+	}
+
+	tests := templateTestList{
+		{`{{whereLabelExists . "com.example.foo" | len}}`, containers, `1`},
+		{`{{whereLabelExists . "com.example.bar" | len}}`, containers, `2`},
+		{`{{whereLabelExists . "com.example.baz" | len}}`, containers, `0`},
+	}
+
+	tests.run(t, "whereLabelExists")
+}
+
+func TestWhereLabelDoesNotExist(t *testing.T) {
+	containers := []*RuntimeContainer{
+		&RuntimeContainer{
+			Labels: map[string]string{
+				"com.example.foo": "foo",
+				"com.example.bar": "bar",
+			},
+			ID: "1",
+		},
+		&RuntimeContainer{
+			Labels: map[string]string{
+				"com.example.bar": "bar",
+			},
+			ID: "2",
+		},
+	}
+
+	tests := templateTestList{
+		{`{{whereLabelDoesNotExist . "com.example.foo" | len}}`, containers, `1`},
+		{`{{whereLabelDoesNotExist . "com.example.bar" | len}}`, containers, `0`},
+		{`{{whereLabelDoesNotExist . "com.example.baz" | len}}`, containers, `2`},
+	}
+
+	tests.run(t, "whereLabelDoesNotExist")
+}
+
+func TestWhereLabelValueMatches(t *testing.T) {
+	containers := []*RuntimeContainer{
+		&RuntimeContainer{
+			Labels: map[string]string{
+				"com.example.foo": "foo",
+				"com.example.bar": "bar",
+			},
+			ID: "1",
+		},
+		&RuntimeContainer{
+			Labels: map[string]string{
+				"com.example.bar": "BAR",
+			},
+			ID: "2",
+		},
+	}
+
+	tests := templateTestList{
+		{`{{whereLabelValueMatches . "com.example.foo" "^foo$" | len}}`, containers, `1`},
+		{`{{whereLabelValueMatches . "com.example.foo" "\\d+" | len}}`, containers, `0`},
+		{`{{whereLabelValueMatches . "com.example.bar" "^bar$" | len}}`, containers, `1`},
+		{`{{whereLabelValueMatches . "com.example.bar" "^(?i)bar$" | len}}`, containers, `2`},
+		{`{{whereLabelValueMatches . "com.example.bar" ".*" | len}}`, containers, `2`},
+		{`{{whereLabelValueMatches . "com.example.baz" ".*" | len}}`, containers, `0`},
+	}
+
+	tests.run(t, "whereLabelValueMatches")
+}
+
 func TestHasPrefix(t *testing.T) {
 	const prefix = "tcp://"
 	const str = "tcp://127.0.0.1:2375"


### PR DESCRIPTION
This PR adds a few functions from the `whereLabel*` family:

* `whereLabelExists`
* `whereLabelDoesNotExist`
* `whereLabelValueMatches`

This should help with situations like those mentioned in https://github.com/jwilder/docker-gen/pull/82#issuecomment-158323192

Right now, these functions are strictly for `[]*RuntimeContainer`, but they could be adjusted to work in other situations if need be. I could also see adding a `hasLabel` function that takes `*RuntimeContainer` or exposing the `regexp.MatchString` function used by `whereLabelValueMatches`, but I wanted to keep this PR simple and focused.