### PR TITLE
Add support for NetworkSettings.Networks

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,4 +1,4 @@
 github.com/BurntSushi/toml f87ce853111478914f0bcffa34d43a93643e6eda
 github.com/Sirupsen/logrus 6ebb4e7b3c24b9fef150d7693e728cb1ebadf1f5
 github.com/docker/docker 2606a2e4d3bf810ec82e373a6cd334e22e504e83
-github.com/fsouza/go-dockerclient 1399676f53e6ccf46e0bf00751b21bed329bc60e
+github.com/fsouza/go-dockerclient 54afc1babbc57f075f958f84904251332bd8fd73

--- a/docker-gen.go
+++ b/docker-gen.go
@@ -55,6 +55,15 @@ type Address struct {
 	HostIP       string
 }
 
+type Network struct {
+	IP                string
+	Name              string
+	Gateway           string
+	EndpointID        string
+	IPv6Gateway       string
+	GlobalIPv6Address string
+}
+
 type Volume struct {
 	Path      string
 	HostPath  string
@@ -64,6 +73,7 @@ type Volume struct {
 type RuntimeContainer struct {
 	ID           string
 	Addresses    []Address
+	Networks     []Network
 	Gateway      string
 	Name         string
 	Hostname     string

--- a/docker-gen.go
+++ b/docker-gen.go
@@ -56,12 +56,15 @@ type Address struct {
 }
 
 type Network struct {
-	IP                string
-	Name              string
-	Gateway           string
-	EndpointID        string
-	IPv6Gateway       string
-	GlobalIPv6Address string
+	IP                  string
+	Name                string
+	Gateway             string
+	EndpointID          string
+	IPv6Gateway         string
+	GlobalIPv6Address   string
+	MacAddress          string
+	GlobalIPv6PrefixLen int
+	IPPrefixLen         int
 }
 
 type Volume struct {

--- a/docker_client.go
+++ b/docker_client.go
@@ -124,6 +124,7 @@ func getContainers(client *docker.Client) ([]*RuntimeContainer, error) {
 			Hostname:     container.Config.Hostname,
 			Gateway:      container.NetworkSettings.Gateway,
 			Addresses:    []Address{},
+			Networks:     []Network{},
 			Env:          make(map[string]string),
 			Volumes:      make(map[string]Volume),
 			Node:         SwarmNode{},
@@ -147,6 +148,19 @@ func getContainers(client *docker.Client) ([]*RuntimeContainer, error) {
 			runtimeContainer.Addresses = append(runtimeContainer.Addresses,
 				address)
 
+		}
+		for k, v := range container.NetworkSettings.Networks {
+			network := Network{
+				IP:                v.IPAddress,
+				Name:              k,
+				Gateway:           v.Gateway,
+				EndpointID:        v.EndpointID,
+				IPv6Gateway:       v.IPv6Gateway,
+				GlobalIPv6Address: v.GlobalIPv6Address,
+			}
+
+			runtimeContainer.Networks = append(runtimeContainer.Networks,
+				network)
 		}
 		for k, v := range container.Volumes {
 			runtimeContainer.Volumes[k] = Volume{

--- a/docker_client.go
+++ b/docker_client.go
@@ -151,12 +151,15 @@ func getContainers(client *docker.Client) ([]*RuntimeContainer, error) {
 		}
 		for k, v := range container.NetworkSettings.Networks {
 			network := Network{
-				IP:                v.IPAddress,
-				Name:              k,
-				Gateway:           v.Gateway,
-				EndpointID:        v.EndpointID,
-				IPv6Gateway:       v.IPv6Gateway,
-				GlobalIPv6Address: v.GlobalIPv6Address,
+				IP:                  v.IPAddress,
+				Name:                k,
+				Gateway:             v.Gateway,
+				EndpointID:          v.EndpointID,
+				IPv6Gateway:         v.IPv6Gateway,
+				GlobalIPv6Address:   v.GlobalIPv6Address,
+				MacAddress:          v.MacAddress,
+				GlobalIPv6PrefixLen: v.GlobalIPv6PrefixLen,
+				IPPrefixLen:         v.IPPrefixLen,
 			}
 
 			runtimeContainer.Networks = append(runtimeContainer.Networks,


### PR DESCRIPTION
## Overview

Latest version of Docker and the go docker client adds `NetworkSettings.Networks`, which contains information for Docker's [multi-host networking](https://docs.docker.com/engine/userguide/networking/get-started-overlay/). This adds support for applications such as your [nginx-proxy](https://github.com/jwilder/nginx-proxy) to route to containers internally across Docker's networks without having to expose ports.

I currently have this running in a production cluster and looks good!