### PR TITLE
Updates for new docker APIs

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,4 +1,2 @@
-github.com/BurntSushi/toml f87ce853111478914f0bcffa34d43a93643e6eda
-github.com/Sirupsen/logrus 6ebb4e7b3c24b9fef150d7693e728cb1ebadf1f5
-github.com/docker/docker 2606a2e4d3bf810ec82e373a6cd334e22e504e83
-github.com/fsouza/go-dockerclient 54afc1babbc57f075f958f84904251332bd8fd73
+github.com/BurntSushi/toml 056c9bc7be7190eaa7715723883caffa5f8fa3e4
+github.com/fsouza/go-dockerclient e0d22d30691bcc996eca51f729a4777b8c7dc2a8

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: docker-gen
 
 docker-gen:
 	echo "Building docker-gen"
-	go build -ldflags "$(LDFLAGS)"
+	go build -ldflags "$(LDFLAGS)" ./cmd/docker-gen
 
 dist-clean:
 	rm -rf dist
@@ -16,12 +16,12 @@ dist-clean:
 	rm -f docker-gen-darwin-*.tar.gz
 
 dist: dist-clean
-	mkdir -p dist/linux/amd64 && GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/linux/amd64/docker-gen
-	mkdir -p dist/linux/i386  && GOOS=linux GOARCH=386 go build -ldflags "$(LDFLAGS)" -o dist/linux/i386/docker-gen
-	mkdir -p dist/linux/armel  && GOOS=linux GOARCH=arm GOARM=5 go build -ldflags "$(LDFLAGS)" -o dist/linux/armel/docker-gen
-	mkdir -p dist/linux/armhf  && GOOS=linux GOARCH=arm GOARM=6 go build -ldflags "$(LDFLAGS)" -o dist/linux/armhf/docker-gen
-	mkdir -p dist/darwin/amd64 && GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/darwin/amd64/docker-gen
-	mkdir -p dist/darwin/i386  && GOOS=darwin GOARCH=386 go build -ldflags "$(LDFLAGS)" -o dist/darwin/i386/docker-gen
+	mkdir -p dist/linux/amd64 && GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/linux/amd64/docker-gen ./cmd/docker-gen
+	mkdir -p dist/linux/i386  && GOOS=linux GOARCH=386 go build -ldflags "$(LDFLAGS)" -o dist/linux/i386/docker-gen ./cmd/docker-gen
+	mkdir -p dist/linux/armel  && GOOS=linux GOARCH=arm GOARM=5 go build -ldflags "$(LDFLAGS)" -o dist/linux/armel/docker-gen ./cmd/docker-gen
+	mkdir -p dist/linux/armhf  && GOOS=linux GOARCH=arm GOARM=6 go build -ldflags "$(LDFLAGS)" -o dist/linux/armhf/docker-gen ./cmd/docker-gen
+	mkdir -p dist/darwin/amd64 && GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/darwin/amd64/docker-gen ./cmd/docker-gen
+	mkdir -p dist/darwin/i386  && GOOS=darwin GOARCH=386 go build -ldflags "$(LDFLAGS)" -o dist/darwin/i386/docker-gen ./cmd/docker-gen
 
 
 release: dist

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ type RuntimeContainer struct {
     IP           string
     IP6LinkLocal string
     IP6Global    string
+    Mounts       []Mount
 }
 
 type Address struct {
@@ -239,6 +240,15 @@ type DockerImage struct {
     Registry   string
     Repository string
     Tag        string
+}
+
+type Mount struct {
+  Name        string
+  Source      string
+  Destination string
+  Driver      string
+  Mode        string
+  RW          bool
 }
 
 type Volume struct {

--- a/README.md
+++ b/README.md
@@ -252,6 +252,21 @@ type SwarmNode struct {
     Name    string
     Address Address
 }
+
+// Accessible from the root in templates as .Docker
+type Docker struct {
+    Name            string
+    NumContainers   int
+    NumImages       int
+    Version         string
+    ApiVersion      string
+    GoVersion       string
+    OperatingSystem string
+    Architecture    string
+}
+
+// Host environment variables accessible from root in templates as .Env
+
 ```
 
 For example, this is a JSON version of an emitted RuntimeContainer struct:

--- a/config.go
+++ b/config.go
@@ -1,0 +1,33 @@
+package dockergen
+
+import "github.com/fsouza/go-dockerclient"
+
+type Config struct {
+	Template         string
+	Dest             string
+	Watch            bool
+	NotifyCmd        string
+	NotifyOutput     bool
+	NotifyContainers map[string]docker.Signal
+	OnlyExposed      bool
+	OnlyPublished    bool
+	Interval         int
+	KeepBlankLines   bool
+}
+
+type ConfigFile struct {
+	Config []Config
+}
+
+func (c *ConfigFile) FilterWatches() ConfigFile {
+	configWithWatches := []Config{}
+
+	for _, config := range c.Config {
+		if config.Watch {
+			configWithWatches = append(configWithWatches, config)
+		}
+	}
+	return ConfigFile{
+		Config: configWithWatches,
+	}
+}

--- a/context.go
+++ b/context.go
@@ -51,6 +51,7 @@ type RuntimeContainer struct {
 	IP           string
 	IP6LinkLocal string
 	IP6Global    string
+	Server       Server
 }
 
 func (r *RuntimeContainer) Equals(o RuntimeContainer) bool {
@@ -88,4 +89,19 @@ type SwarmNode struct {
 	ID      string
 	Name    string
 	Address Address
+}
+
+type Server struct {
+	Name          string
+	NumContainers int
+	NumImages     int
+	Docker        Docker
+}
+
+type Docker struct {
+	Version         string
+	ApiVersion      string
+	GoVersion       string
+	OperatingSystem string
+	Architecture    string
 }

--- a/context.go
+++ b/context.go
@@ -1,0 +1,91 @@
+package dockergen
+
+import "os"
+
+type Context []*RuntimeContainer
+
+func (c *Context) Env() map[string]string {
+	return splitKeyValueSlice(os.Environ())
+}
+
+type Address struct {
+	IP           string
+	IP6LinkLocal string
+	IP6Global    string
+	Port         string
+	HostPort     string
+	Proto        string
+	HostIP       string
+}
+
+type Network struct {
+	IP                  string
+	Name                string
+	Gateway             string
+	EndpointID          string
+	IPv6Gateway         string
+	GlobalIPv6Address   string
+	MacAddress          string
+	GlobalIPv6PrefixLen int
+	IPPrefixLen         int
+}
+
+type Volume struct {
+	Path      string
+	HostPath  string
+	ReadWrite bool
+}
+
+type RuntimeContainer struct {
+	ID           string
+	Addresses    []Address
+	Networks     []Network
+	Gateway      string
+	Name         string
+	Hostname     string
+	Image        DockerImage
+	Env          map[string]string
+	Volumes      map[string]Volume
+	Node         SwarmNode
+	Labels       map[string]string
+	IP           string
+	IP6LinkLocal string
+	IP6Global    string
+}
+
+func (r *RuntimeContainer) Equals(o RuntimeContainer) bool {
+	return r.ID == o.ID && r.Image == o.Image
+}
+
+func (r *RuntimeContainer) PublishedAddresses() []Address {
+	mapped := []Address{}
+	for _, address := range r.Addresses {
+		if address.HostPort != "" {
+			mapped = append(mapped, address)
+		}
+	}
+	return mapped
+}
+
+type DockerImage struct {
+	Registry   string
+	Repository string
+	Tag        string
+}
+
+func (i *DockerImage) String() string {
+	ret := i.Repository
+	if i.Registry != "" {
+		ret = i.Registry + "/" + i.Repository
+	}
+	if i.Tag != "" {
+		ret = ret + ":" + i.Tag
+	}
+	return ret
+}
+
+type SwarmNode struct {
+	ID      string
+	Name    string
+	Address Address
+}

--- a/context.go
+++ b/context.go
@@ -89,6 +89,7 @@ type RuntimeContainer struct {
 	IP           string
 	IP6LinkLocal string
 	IP6Global    string
+	Mounts       []Mount
 }
 
 func (r *RuntimeContainer) Equals(o RuntimeContainer) bool {
@@ -126,6 +127,15 @@ type SwarmNode struct {
 	ID      string
 	Name    string
 	Address Address
+}
+
+type Mount struct {
+	Name        string
+	Source      string
+	Destination string
+	Driver      string
+	Mode        string
+	RW          bool
 }
 
 type Docker struct {

--- a/docker_client.go
+++ b/docker_client.go
@@ -3,7 +3,6 @@ package dockergen
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -118,99 +117,6 @@ func splitDockerImage(img string) (string, string, string) {
 	}
 
 	return registry, repository, tag
-}
-
-func GetContainers(client *docker.Client) ([]*RuntimeContainer, error) {
-	apiContainers, err := client.ListContainers(docker.ListContainersOptions{
-		All:  false,
-		Size: false,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	containers := []*RuntimeContainer{}
-	for _, apiContainer := range apiContainers {
-		container, err := client.InspectContainer(apiContainer.ID)
-		if err != nil {
-			log.Printf("error inspecting container: %s: %s\n", apiContainer.ID, err)
-			continue
-		}
-
-		registry, repository, tag := splitDockerImage(container.Config.Image)
-		runtimeContainer := &RuntimeContainer{
-			ID: container.ID,
-			Image: DockerImage{
-				Registry:   registry,
-				Repository: repository,
-				Tag:        tag,
-			},
-			Name:         strings.TrimLeft(container.Name, "/"),
-			Hostname:     container.Config.Hostname,
-			Gateway:      container.NetworkSettings.Gateway,
-			Addresses:    []Address{},
-			Networks:     []Network{},
-			Env:          make(map[string]string),
-			Volumes:      make(map[string]Volume),
-			Node:         SwarmNode{},
-			Labels:       make(map[string]string),
-			IP:           container.NetworkSettings.IPAddress,
-			IP6LinkLocal: container.NetworkSettings.LinkLocalIPv6Address,
-			IP6Global:    container.NetworkSettings.GlobalIPv6Address,
-		}
-		for k, v := range container.NetworkSettings.Ports {
-			address := Address{
-				IP:           container.NetworkSettings.IPAddress,
-				IP6LinkLocal: container.NetworkSettings.LinkLocalIPv6Address,
-				IP6Global:    container.NetworkSettings.GlobalIPv6Address,
-				Port:         k.Port(),
-				Proto:        k.Proto(),
-			}
-			if len(v) > 0 {
-				address.HostPort = v[0].HostPort
-				address.HostIP = v[0].HostIP
-			}
-			runtimeContainer.Addresses = append(runtimeContainer.Addresses,
-				address)
-
-		}
-		for k, v := range container.NetworkSettings.Networks {
-			network := Network{
-				IP:                  v.IPAddress,
-				Name:                k,
-				Gateway:             v.Gateway,
-				EndpointID:          v.EndpointID,
-				IPv6Gateway:         v.IPv6Gateway,
-				GlobalIPv6Address:   v.GlobalIPv6Address,
-				MacAddress:          v.MacAddress,
-				GlobalIPv6PrefixLen: v.GlobalIPv6PrefixLen,
-				IPPrefixLen:         v.IPPrefixLen,
-			}
-
-			runtimeContainer.Networks = append(runtimeContainer.Networks,
-				network)
-		}
-		for k, v := range container.Volumes {
-			runtimeContainer.Volumes[k] = Volume{
-				Path:      k,
-				HostPath:  v,
-				ReadWrite: container.VolumesRW[k],
-			}
-		}
-		if container.Node != nil {
-			runtimeContainer.Node.ID = container.Node.ID
-			runtimeContainer.Node.Name = container.Node.Name
-			runtimeContainer.Node.Address = Address{
-				IP: container.Node.IP,
-			}
-		}
-
-		runtimeContainer.Env = splitKeyValueSlice(container.Config.Env)
-		runtimeContainer.Labels = container.Config.Labels
-		containers = append(containers, runtimeContainer)
-	}
-	return containers, nil
-
 }
 
 // pathExists returns whether the given file or directory exists or not

--- a/docker_client.go
+++ b/docker_client.go
@@ -1,4 +1,4 @@
-package main
+package dockergen
 
 import (
 	"fmt"
@@ -94,7 +94,7 @@ func splitDockerImage(img string) (string, string, string) {
 	return registry, repository, tag
 }
 
-func getContainers(client *docker.Client) ([]*RuntimeContainer, error) {
+func GetContainers(client *docker.Client) ([]*RuntimeContainer, error) {
 
 	apiContainers, err := client.ListContainers(docker.ListContainersOptions{
 		All:  false,

--- a/docker_client_test.go
+++ b/docker_client_test.go
@@ -1,4 +1,4 @@
-package main
+package dockergen
 
 import (
 	"testing"

--- a/generator.go
+++ b/generator.go
@@ -337,6 +337,17 @@ func (g *generator) getContainers(client *docker.Client) ([]*RuntimeContainer, e
 			}
 		}
 
+		for _, v := range container.Mounts {
+			runtimeContainer.Mounts = append(runtimeContainer.Mounts, Mount{
+				Name:        v.Name,
+				Source:      v.Source,
+				Destination: v.Destination,
+				Driver:      v.Driver,
+				Mode:        v.Mode,
+				RW:          v.RW,
+			})
+		}
+
 		runtimeContainer.Env = splitKeyValueSlice(container.Config.Env)
 		runtimeContainer.Labels = container.Config.Labels
 		containers = append(containers, runtimeContainer)

--- a/generator.go
+++ b/generator.go
@@ -1,0 +1,240 @@
+package dockergen
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsouza/go-dockerclient"
+)
+
+type generator struct {
+	Client                     *docker.Client
+	Configs                    ConfigFile
+	Endpoint                   string
+	TLSVerify                  bool
+	TLSCert, TLSCaCert, TLSKey string
+
+	dockerInfo Server
+
+	wg sync.WaitGroup
+}
+
+type GeneratorConfig struct {
+	Endpoint string
+
+	TLSCert   string
+	TLSKey    string
+	TLSCACert string
+	TLSVerify bool
+
+	ConfigFile ConfigFile
+}
+
+func NewGenerator(gc GeneratorConfig) (*generator, error) {
+	endpoint, err := GetEndpoint(gc.Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("Bad endpoint: %s", err)
+	}
+
+	client, err := NewDockerClient(endpoint, gc.TLSVerify, gc.TLSCert, gc.TLSCACert, gc.TLSKey)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to create docker client: %s", err)
+	}
+
+	return &generator{
+		Client:    client,
+		Endpoint:  gc.Endpoint,
+		TLSVerify: gc.TLSVerify,
+		TLSCert:   gc.TLSCert,
+		TLSCaCert: gc.TLSCACert,
+		TLSKey:    gc.TLSKey,
+		Configs:   gc.ConfigFile,
+	}, nil
+}
+
+func (g *generator) Generate() error {
+	g.generateFromContainers(g.Client)
+	g.generateAtInterval(g.Client, g.Configs)
+	g.generateFromEvents(g.Client, g.Configs)
+	g.wg.Wait()
+
+	return nil
+}
+
+func (g *generator) generateFromContainers(client *docker.Client) {
+	containers, err := GetContainers(client)
+	if err != nil {
+		log.Printf("error listing containers: %s\n", err)
+		return
+	}
+	for _, config := range g.Configs.Config {
+		changed := GenerateFile(config, containers)
+		if !changed {
+			log.Printf("Contents of %s did not change. Skipping notification '%s'", config.Dest, config.NotifyCmd)
+			continue
+		}
+		g.runNotifyCmd(config)
+		g.sendSignalToContainer(client, config)
+	}
+}
+
+func (g *generator) generateAtInterval(client *docker.Client, configs ConfigFile) {
+	for _, config := range configs.Config {
+
+		if config.Interval == 0 {
+			continue
+		}
+
+		log.Printf("Generating every %d seconds", config.Interval)
+		g.wg.Add(1)
+		ticker := time.NewTicker(time.Duration(config.Interval) * time.Second)
+		quit := make(chan struct{})
+		configCopy := config
+		go func() {
+			defer g.wg.Done()
+			for {
+				select {
+				case <-ticker.C:
+					containers, err := GetContainers(client)
+					if err != nil {
+						log.Printf("Error listing containers: %s\n", err)
+						continue
+					}
+					// ignore changed return value. always run notify command
+					GenerateFile(configCopy, containers)
+					g.runNotifyCmd(configCopy)
+					g.sendSignalToContainer(client, configCopy)
+				case <-quit:
+					ticker.Stop()
+					return
+				}
+			}
+		}()
+	}
+}
+
+func (g *generator) generateFromEvents(client *docker.Client, configs ConfigFile) {
+	configs = configs.FilterWatches()
+	if len(configs.Config) == 0 {
+		return
+	}
+
+	g.wg.Add(1)
+	defer g.wg.Done()
+
+	for {
+		if client == nil {
+			var err error
+			endpoint, err := GetEndpoint(g.Endpoint)
+			if err != nil {
+				log.Printf("Bad endpoint: %s", err)
+				time.Sleep(10 * time.Second)
+				continue
+			}
+
+			client, err = NewDockerClient(endpoint, g.TLSVerify, g.TLSCert, g.TLSCaCert, g.TLSKey)
+			if err != nil {
+				log.Printf("Unable to connect to docker daemon: %s", err)
+				time.Sleep(10 * time.Second)
+				continue
+			}
+			g.generateFromContainers(client)
+		}
+
+		eventChan := make(chan *docker.APIEvents, 100)
+		defer close(eventChan)
+
+		watching := false
+		for {
+
+			if client == nil {
+				break
+			}
+			err := client.Ping()
+			if err != nil {
+				log.Printf("Unable to ping docker daemon: %s", err)
+				if watching {
+					client.RemoveEventListener(eventChan)
+					watching = false
+					client = nil
+				}
+				time.Sleep(10 * time.Second)
+				break
+
+			}
+
+			if !watching {
+				err = client.AddEventListener(eventChan)
+				if err != nil && err != docker.ErrListenerAlreadyExists {
+					log.Printf("Error registering docker event listener: %s", err)
+					time.Sleep(10 * time.Second)
+					continue
+				}
+				watching = true
+				log.Println("Watching docker events")
+			}
+
+			select {
+
+			case event := <-eventChan:
+				if event == nil {
+					if watching {
+						client.RemoveEventListener(eventChan)
+						watching = false
+						client = nil
+					}
+					break
+				}
+
+				if event.Status == "start" || event.Status == "stop" || event.Status == "die" {
+					log.Printf("Received event %s for container %s", event.Status, event.ID[:12])
+					g.generateFromContainers(client)
+				}
+			case <-time.After(10 * time.Second):
+				// check for docker liveness
+			}
+
+		}
+	}
+}
+
+func (g *generator) runNotifyCmd(config Config) {
+	if config.NotifyCmd == "" {
+		return
+	}
+
+	log.Printf("Running '%s'", config.NotifyCmd)
+	cmd := exec.Command("/bin/sh", "-c", config.NotifyCmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Error running notify command: %s, %s\n", config.NotifyCmd, err)
+	}
+	if config.NotifyOutput {
+		for _, line := range strings.Split(string(out), "\n") {
+			if line != "" {
+				log.Printf("[%s]: %s", config.NotifyCmd, line)
+			}
+		}
+	}
+}
+
+func (g *generator) sendSignalToContainer(client *docker.Client, config Config) {
+	if len(config.NotifyContainers) < 1 {
+		return
+	}
+
+	for container, signal := range config.NotifyContainers {
+		log.Printf("Sending container '%s' signal '%v'", container, signal)
+		killOpts := docker.KillContainerOptions{
+			ID:     container,
+			Signal: signal,
+		}
+		if err := client.KillContainer(killOpts); err != nil {
+			log.Printf("Error sending signal to container: %s", err)
+		}
+	}
+}

--- a/reflect.go
+++ b/reflect.go
@@ -1,4 +1,4 @@
-package main
+package dockergen
 
 import (
 	"log"

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -1,4 +1,4 @@
-package main
+package dockergen
 
 import "testing"
 

--- a/template.go
+++ b/template.go
@@ -1,4 +1,4 @@
-package main
+package dockergen
 
 import (
 	"bytes"
@@ -425,7 +425,7 @@ func newTemplate(name string) *template.Template {
 	return tmpl
 }
 
-func generateFile(config Config, containers Context) bool {
+func GenerateFile(config Config, containers Context) bool {
 	filteredContainers := Context{}
 	if config.OnlyPublished {
 		for _, container := range containers {

--- a/template_test.go
+++ b/template_test.go
@@ -1,4 +1,4 @@
-package main
+package dockergen
 
 import (
 	"bytes"

--- a/templates/etcd.tmpl
+++ b/templates/etcd.tmpl
@@ -2,6 +2,7 @@
 #!/bin/bash
 
 # Genenerated by {{ .Env.USER }}
+# Docker Version {{ .Docker.Version }}
 
 {{range $key, $value := .}}
 {{ $addrLen := len $value.Addresses }}

--- a/utils.go
+++ b/utils.go
@@ -1,4 +1,4 @@
-package main
+package dockergen
 
 import (
 	"bufio"
@@ -8,7 +8,7 @@ import (
 	"unicode"
 )
 
-func getEndpoint() (string, error) {
+func GetEndpoint(endpoint string) (string, error) {
 	defaultEndpoint := "unix:///var/run/docker.sock"
 	if os.Getenv("DOCKER_HOST") != "" {
 		defaultEndpoint = os.Getenv("DOCKER_HOST")
@@ -40,18 +40,6 @@ func splitKeyValueSlice(in []string) map[string]string {
 	}
 	return env
 
-}
-
-// pathExists returns whether the given file or directory exists or not
-func pathExists(path string) (bool, error) {
-	_, err := os.Stat(path)
-	if err == nil {
-		return true, nil
-	}
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	return false, err
 }
 
 func isBlank(str string) bool {

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,8 +1,7 @@
-package main
+package dockergen
 
 import (
 	"bytes"
-	"flag"
 	"os"
 	"strings"
 	"testing"
@@ -14,7 +13,7 @@ func TestDefaultEndpoint(t *testing.T) {
 		t.Fatalf("Unable to unset DOCKER_HOST: %s", err)
 	}
 
-	endpoint, err := getEndpoint()
+	endpoint, err := GetEndpoint("")
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
@@ -29,7 +28,7 @@ func TestDockerHostEndpoint(t *testing.T) {
 		t.Fatalf("Unable to set DOCKER_HOST: %s", err)
 	}
 
-	endpoint, err := getEndpoint()
+	endpoint, err := GetEndpoint("")
 	if err != nil {
 		t.Fatal("%s", err)
 	}
@@ -41,19 +40,13 @@ func TestDockerHostEndpoint(t *testing.T) {
 
 func TestDockerFlagEndpoint(t *testing.T) {
 
-	initFlags()
 	err := os.Setenv("DOCKER_HOST", "tcp://127.0.0.1:4243")
 	if err != nil {
 		t.Fatalf("Unable to set DOCKER_HOST: %s", err)
 	}
 
 	// flag value should override DOCKER_HOST and default value
-	err = flag.Set("endpoint", "tcp://127.0.0.1:5555")
-	if err != nil {
-		t.Fatalf("Unable to set endpoint flag: %s", err)
-	}
-
-	endpoint, err := getEndpoint()
+	endpoint, err := GetEndpoint("tcp://127.0.0.1:5555")
 	if err != nil {
 		t.Fatal("%s", err)
 	}
@@ -63,8 +56,8 @@ func TestDockerFlagEndpoint(t *testing.T) {
 }
 
 func TestUnixBadFormat(t *testing.T) {
-	endpoint = "unix:/var/run/docker.sock"
-	_, err := getEndpoint()
+	endpoint := "unix:/var/run/docker.sock"
+	_, err := GetEndpoint(endpoint)
 	if err == nil {
 		t.Fatal("endpoint should have failed")
 	}


### PR DESCRIPTION
This pulls in changes from #128 #119 and some of the work/ideas from #131.

Features:
* `Mounts` added to `RuntimeContainer` - allows access to `Mount` info for a container.
* `Docker` added to `Context` - allows accessing docker daemon info, num containers/images, etc..

The code has been re-organized a bit to move towards a library with `docker-gen` under the `cmd` package to keep it `go install`able.