### PR TITLE
Deal with networks (supports new overlay network)

### DIFF
--- a/templates/nginx.tmpl
+++ b/templates/nginx.tmpl
@@ -12,20 +12,22 @@ upstream {{ $host }} {
 {{ range $index, $value := $containers }}
 
 	{{ $addrLen := len $value.Addresses }}
+	{{ $network := index $value.Networks 0 }}
+	
 	{{/* If only 1 port exposed, use that */}}
 	{{ if eq $addrLen 1 }}
 		{{ with $address := index $value.Addresses 0 }}
-		   # {{$value.Name}}
-		   server {{ $address.IP }}:{{ $address.Port }};
+			# {{$value.Name}}
+			server {{ $network.IP }}:{{ $address.Port }};
 		{{ end }}
 
 	{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var */}}
 	{{ else if $value.Env.VIRTUAL_PORT }}
 		{{ range $i, $address := $value.Addresses }}
-		   {{ if eq $address.Port $value.Env.VIRTUAL_PORT }}
-		   # {{$value.Name}}
-		   server {{ $address.IP }}:{{ $address.Port }};
-		   {{ end }}
+			{{ if eq $address.Port $value.Env.VIRTUAL_PORT }}
+			# {{$value.Name}}
+			server {{ $network.IP }}:{{ $address.Port }};
+			{{ end }}
 		{{ end }}
 
 	{{/* Else default to standard web port 80 */}}
@@ -33,7 +35,7 @@ upstream {{ $host }} {
 		{{ range $i, $address := $value.Addresses }}
 			{{ if eq $address.Port "80" }}
 			# {{$value.Name}}
-			server {{ $address.IP }}:{{ $address.Port }};
+			server {{ $network.IP }}:{{ $address.Port }};
 			{{ end }}
 		{{ end }}
 	{{ end }}


### PR DESCRIPTION
Initial template works with current model network.

If you use the new overlay network (ex. docker-compose --x-networking up), the golang structure RuntimeContainer -> []Address doesn't contain IP (empty string).

Use []Network array resolved the problem.