### PR TITLE
Add -wait parameter to debounce watched events

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Options:
       show version
   -watch
       watch for container changes
+  -wait
+      minimum (and/or maximum) duration to wait after each container change before triggering
 
 Arguments:
   template - path to a template to generate
@@ -153,6 +155,9 @@ path to a template to generate
 watch = true
 watch for container changes
 
+wait = "500ms:2s"
+debounce changes with a min:max duration. Only applicable if watch = true
+
 
 [config.NotifyContainers]
 Starts a notify container section
@@ -180,6 +185,7 @@ watch = true
 template = "/etc/docker-gen/templates/nginx.tmpl"
 dest = "/etc/nginx/conf.d/default.conf"
 watch = true
+wait = "500ms:2s"
 
 [config.NotifyContainers]
 nginx = 1  # 1 is a signal number to be sent; here SIGINT

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -19,6 +19,7 @@ var (
 	buildVersion            string
 	version                 bool
 	watch                   bool
+	wait                    string
 	notifyCmd               string
 	notifyOutput            bool
 	notifySigHUPContainerID string
@@ -85,6 +86,7 @@ func initFlags() {
 	}
 	flag.BoolVar(&version, "version", false, "show version")
 	flag.BoolVar(&watch, "watch", false, "watch for container changes")
+	flag.StringVar(&wait, "wait", "", "minimum and maximum durations to wait (e.g. \"500ms:2s\") before triggering generate")
 	flag.BoolVar(&onlyExposed, "only-exposed", false, "only include containers with exposed ports")
 
 	flag.BoolVar(&onlyPublished, "only-published", false,
@@ -127,10 +129,15 @@ func main() {
 			}
 		}
 	} else {
+		w, err := dockergen.ParseWait(wait)
+		if err != nil {
+			log.Fatalf("error parsing wait interval: %s\n", err)
+		}
 		config := dockergen.Config{
 			Template:         flag.Arg(0),
 			Dest:             flag.Arg(1),
 			Watch:            watch,
+			Wait:             w,
 			NotifyCmd:        notifyCmd,
 			NotifyOutput:     notifyOutput,
 			NotifyContainers: make(map[string]docker.Signal),

--- a/config.go
+++ b/config.go
@@ -1,11 +1,18 @@
 package dockergen
 
-import "github.com/fsouza/go-dockerclient"
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/fsouza/go-dockerclient"
+)
 
 type Config struct {
 	Template         string
 	Dest             string
 	Watch            bool
+	Wait             *Wait
 	NotifyCmd        string
 	NotifyOutput     bool
 	NotifyContainers map[string]docker.Signal
@@ -30,4 +37,48 @@ func (c *ConfigFile) FilterWatches() ConfigFile {
 	return ConfigFile{
 		Config: configWithWatches,
 	}
+}
+
+type Wait struct {
+	Min time.Duration
+	Max time.Duration
+}
+
+func (w *Wait) UnmarshalText(text []byte) error {
+	wait, err := ParseWait(string(text))
+	if err == nil {
+		w.Min, w.Max = wait.Min, wait.Max
+	}
+	return err
+}
+
+func ParseWait(s string) (*Wait, error) {
+	if len(strings.TrimSpace(s)) < 1 {
+		return &Wait{0, 0}, nil
+	}
+
+	parts := strings.Split(s, ":")
+
+	var (
+		min time.Duration
+		max time.Duration
+		err error
+	)
+	min, err = time.ParseDuration(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return nil, err
+	}
+	if len(parts) > 1 {
+		max, err = time.ParseDuration(strings.TrimSpace(parts[1]))
+		if err != nil {
+			return nil, err
+		}
+		if max < min {
+			return nil, errors.New("Invalid wait interval: max must be larger than min")
+		}
+	} else {
+		max = 4 * min
+	}
+
+	return &Wait{min, max}, nil
 }

--- a/generator_test.go
+++ b/generator_test.go
@@ -1,0 +1,207 @@
+package dockergen
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fsouza/go-dockerclient"
+	dockertest "github.com/fsouza/go-dockerclient/testing"
+)
+
+func TestGenerateFromEvents(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	containerID := "8dfafdbc3a40"
+	counter := 0
+
+	eventsResponse := `
+{"status":"start","id":"8dfafdbc3a40","from":"base:latest","time":1374067924}
+{"status":"stop","id":"8dfafdbc3a40","from":"base:latest","time":1374067966}
+{"status":"start","id":"8dfafdbc3a40","from":"base:latest","time":1374067970}
+{"status":"destroy","id":"8dfafdbc3a40","from":"base:latest","time":1374067990}`
+	infoResponse := `{"Containers":1,"Images":1,"Debug":0,"NFd":11,"NGoroutines":21,"MemoryLimit":1,"SwapLimit":0}`
+	versionResponse := `{"Version":"1.8.0","Os":"Linux","KernelVersion":"3.18.5-tinycore64","GoVersion":"go1.4.1","GitCommit":"a8a31ef","Arch":"amd64","ApiVersion":"1.19"}`
+
+	server, _ := dockertest.NewServer("127.0.0.1:0", nil, nil)
+	server.CustomHandler("/events", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rsc := bufio.NewScanner(strings.NewReader(eventsResponse))
+		for rsc.Scan() {
+			w.Write([]byte(rsc.Text()))
+			w.(http.Flusher).Flush()
+			time.Sleep(15 * time.Millisecond)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}))
+	server.CustomHandler("/info", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(infoResponse))
+		w.(http.Flusher).Flush()
+	}))
+	server.CustomHandler("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(versionResponse))
+		w.(http.Flusher).Flush()
+	}))
+	server.CustomHandler("/containers/json", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result := []docker.APIContainers{
+			docker.APIContainers{
+				ID:      containerID,
+				Image:   "base:latest",
+				Command: "/bin/sh",
+				Created: time.Now().Unix(),
+				Status:  "running",
+				Ports:   []docker.APIPort{},
+				Names:   []string{"/docker-gen-test"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(result)
+	}))
+	server.CustomHandler(fmt.Sprintf("/containers/%s/json", containerID), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		counter++
+		container := docker.Container{
+			Name:    "docker-gen-test",
+			ID:      containerID,
+			Created: time.Now(),
+			Path:    "/bin/sh",
+			Args:    []string{},
+			Config: &docker.Config{
+				Hostname:     "docker-gen",
+				AttachStdout: true,
+				AttachStderr: true,
+				Env:          []string{fmt.Sprintf("COUNTER=%d", counter)},
+				Cmd:          []string{"/bin/sh"},
+				Image:        "base:latest",
+			},
+			State: docker.State{
+				Running:   true,
+				Pid:       400,
+				ExitCode:  0,
+				StartedAt: time.Now(),
+			},
+			Image: "0ff407d5a7d9ed36acdf3e75de8cc127afecc9af234d05486be2981cdc01a38d",
+			NetworkSettings: &docker.NetworkSettings{
+				IPAddress:   fmt.Sprintf("10.0.0.10"),
+				IPPrefixLen: 24,
+				Gateway:     "10.0.0.1",
+				Bridge:      "docker0",
+				PortMapping: map[string]docker.PortMapping{},
+				Ports:       map[docker.Port][]docker.PortBinding{},
+			},
+			ResolvConfPath: "/etc/resolv.conf",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(container)
+	}))
+
+	serverURL := fmt.Sprintf("tcp://%s", strings.TrimRight(strings.TrimPrefix(server.URL(), "http://"), "/"))
+	client, err := NewDockerClient(serverURL, false, "", "", "")
+	if err != nil {
+		t.Errorf("Failed to create client: %s", err)
+	}
+	client.SkipServerVersionCheck = true
+
+	tmplFile, err := ioutil.TempFile(os.TempDir(), "docker-gen-tmpl")
+	if err != nil {
+		t.Errorf("Failed to create temp file: %v\n", err)
+	}
+	defer func() {
+		tmplFile.Close()
+		os.Remove(tmplFile.Name())
+	}()
+	err = ioutil.WriteFile(tmplFile.Name(), []byte("{{range $key, $value := .}}{{$value.ID}}.{{$value.Env.COUNTER}}{{end}}"), 0644)
+	if err != nil {
+		t.Errorf("Failed to write to temp file: %v\n", err)
+	}
+
+	var destFiles []*os.File
+	for i := 0; i < 4; i++ {
+		destFile, err := ioutil.TempFile(os.TempDir(), "docker-gen-out")
+		if err != nil {
+			t.Errorf("Failed to create temp file: %v\n", err)
+		}
+		destFiles = append(destFiles, destFile)
+	}
+	defer func() {
+		for _, destFile := range destFiles {
+			destFile.Close()
+			os.Remove(destFile.Name())
+		}
+	}()
+
+	apiVersion, err := client.Version()
+	if err != nil {
+		t.Errorf("Failed to retrieve docker server version info: %v\n", err)
+	}
+	SetDockerEnv(apiVersion) // prevents a panic
+
+	generator := &generator{
+		Client:   client,
+		Endpoint: serverURL,
+		Configs: ConfigFile{
+			[]Config{
+				Config{
+					Template: tmplFile.Name(),
+					Dest:     destFiles[0].Name(),
+					Watch:    false,
+				},
+				Config{
+					Template: tmplFile.Name(),
+					Dest:     destFiles[1].Name(),
+					Watch:    true,
+					Wait:     &Wait{0, 0},
+				},
+				Config{
+					Template: tmplFile.Name(),
+					Dest:     destFiles[2].Name(),
+					Watch:    true,
+					Wait:     &Wait{20 * time.Millisecond, 25 * time.Millisecond},
+				},
+				Config{
+					Template: tmplFile.Name(),
+					Dest:     destFiles[3].Name(),
+					Watch:    true,
+					Wait:     &Wait{25 * time.Millisecond, 100 * time.Millisecond},
+				},
+			},
+		},
+		retry: false,
+	}
+
+	generator.generateFromEvents()
+	generator.wg.Wait()
+
+	var (
+		value    []byte
+		expected string
+	)
+
+	// The counter is incremented in each output file in the following sequence:
+	//
+	//       init   0ms    5ms    10ms   15ms   20ms   25ms   30ms   35ms   40ms   45ms   50ms   55ms
+	//       ├──────╫──────┼──────┼──────╫──────┼──────┼──────╫──────┼──────┼──────┼──────┼──────┤
+	// File0 ├─ 1   ║                    ║                    ║
+	// File1 ├─ 1   ╟─ 2                 ╟─ 3                 ╟─ 5
+	// File2 ├─ 1   ╟───── max (25ms) ───║───────────> 4      ╟─────── min (20ms) ──────> 6
+	// File3 └─ 1   ╟──────────────────> ╟──────────────────> ╟─────────── min (25ms) ─────────> 7
+	//          ┌───╨───┐            ┌───╨──┐             ┌───╨───┐
+	//          │ start │            │ stop │             │ start │
+	//          └───────┘            └──────┘             └───────┘
+
+	expectedCounters := []int{1, 5, 6, 7}
+
+	for i, counter := range expectedCounters {
+		value, _ = ioutil.ReadFile(destFiles[i].Name())
+		expected = fmt.Sprintf("%s.%d", containerID, counter)
+		if string(value) != expected {
+			t.Errorf("expected: %s. got: %s", expected, value)
+		}
+	}
+}


### PR DESCRIPTION
Addresses the following issues: #42, #43, #57, #103, #136

This is a rewrite of `generateFromEvents` that makes the following changes:

* Only configs that have `watch = true` will be generated upon container events.
* All configs will be regenerated when the events channel is reattached, rather than upon docker client re-initialization. (avoids missing out on events in between)
* Each config with `watch` now has its own separate channel. This is to enable individual debouncing parameters, specified with the `wait` parameter. Syntax is `min:max`, e.g. `500ms:2s`. This feature is referenced from `hashicorp/envconsul`

I've also added an integration test for `generator.go` that verifies the `wait` parameter :)