### PR TITLE
Add CurrentContainerID into Docker struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,14 +272,15 @@ type SwarmNode struct {
 
 // Accessible from the root in templates as .Docker
 type Docker struct {
-    Name            string
-    NumContainers   int
-    NumImages       int
-    Version         string
-    ApiVersion      string
-    GoVersion       string
-    OperatingSystem string
-    Architecture    string
+    Name                 string
+    NumContainers        int
+    NumImages            int
+    Version              string
+    ApiVersion           string
+    GoVersion            string
+    OperatingSystem      string
+    Architecture         string
+    CurrentContainerName string
 }
 
 // Host environment variables accessible from root in templates as .Env

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ type Docker struct {
     GoVersion            string
     OperatingSystem      string
     Architecture         string
-    CurrentContainerName string
+    CurrentContainerID   string
 }
 
 // Host environment variables accessible from root in templates as .Env

--- a/context.go
+++ b/context.go
@@ -32,15 +32,15 @@ func SetServerInfo(d *docker.Env) {
 	mu.Lock()
 	defer mu.Unlock()
 	dockerInfo = Docker{
-		Name:                 d.Get("Name"),
-		NumContainers:        d.GetInt("Containers"),
-		NumImages:            d.GetInt("Images"),
-		Version:              dockerEnv.Get("Version"),
-		ApiVersion:           dockerEnv.Get("ApiVersion"),
-		GoVersion:            dockerEnv.Get("GoVersion"),
-		OperatingSystem:      dockerEnv.Get("Os"),
-		Architecture:         dockerEnv.Get("Arch"),
-		CurrentContainerID:   GetCurrentContainerID(),
+		Name:               d.Get("Name"),
+		NumContainers:      d.GetInt("Containers"),
+		NumImages:          d.GetInt("Images"),
+		Version:            dockerEnv.Get("Version"),
+		ApiVersion:         dockerEnv.Get("ApiVersion"),
+		GoVersion:          dockerEnv.Get("GoVersion"),
+		OperatingSystem:    dockerEnv.Get("Os"),
+		Architecture:       dockerEnv.Get("Arch"),
+		CurrentContainerID: GetCurrentContainerID(),
 	}
 }
 
@@ -143,15 +143,15 @@ type Mount struct {
 }
 
 type Docker struct {
-	Name                 string
-	NumContainers        int
-	NumImages            int
-	Version              string
-	ApiVersion           string
-	GoVersion            string
-	OperatingSystem      string
-	Architecture         string
-	CurrentContainerID   string
+	Name               string
+	NumContainers      int
+	NumImages          int
+	Version            string
+	ApiVersion         string
+	GoVersion          string
+	OperatingSystem    string
+	Architecture       string
+	CurrentContainerID string
 }
 
 func GetCurrentContainerID() string {
@@ -163,11 +163,10 @@ func GetCurrentContainerID() string {
 		log.Printf("Fail to open /proc/self/cgroup: %s\n", err)
 		return ""
 	}
-	
-	reader := bufio.NewReader(file)
-    scanner := bufio.NewScanner(reader)
-    scanner.Split(bufio.ScanLines)
 
+	reader := bufio.NewReader(file)
+	scanner := bufio.NewScanner(reader)
+	scanner.Split(bufio.ScanLines)
 
 	for scanner.Scan() {
 		_, lines, err := bufio.ScanLines([]byte(scanner.Text()), true)
@@ -176,11 +175,11 @@ func GetCurrentContainerID() string {
 			if re.MatchString(string(lines)) {
 				submatches := re.FindStringSubmatch(string(lines))
 				containerID := submatches[1]
-				
+
 				return containerID
 			}
 		}
-    }
+	}
 
 	return ""
 }

--- a/context.go
+++ b/context.go
@@ -158,10 +158,6 @@ func GetCurrentContainerID() string {
 	file, err := os.Open("/proc/self/cgroup")
 
 	if err != nil {
-		if os.IsExist(err) {
-			log.Printf("Fail to open /proc/self/cgroup: %s\n", err)
-		}
-
 		return ""
 	}
 

--- a/context.go
+++ b/context.go
@@ -157,10 +157,11 @@ type Docker struct {
 func GetCurrentContainerID() string {
 	file, err := os.Open("/proc/self/cgroup")
 
-	if os.IsNotExist(err) {
-		return ""
-	} else if err != nil {
-		log.Printf("Fail to open /proc/self/cgroup: %s\n", err)
+	if err != nil {
+		if os.IsExist(err) {
+			log.Printf("Fail to open /proc/self/cgroup: %s\n", err)
+		}
+
 		return ""
 	}
 

--- a/context.go
+++ b/context.go
@@ -168,10 +168,12 @@ func GetCurrentContainerID() string {
 	scanner := bufio.NewScanner(reader)
 	scanner.Split(bufio.ScanLines)
 
+	regex := "/docker/([[:alnum:]]{64})$"
+	re := regexp.MustCompilePOSIX(regex)
+
 	for scanner.Scan() {
 		_, lines, err := bufio.ScanLines([]byte(scanner.Text()), true)
 		if err == nil {
-			re := regexp.MustCompilePOSIX("/docker/([[:alnum:]]{64})$")
 			if re.MatchString(string(lines)) {
 				submatches := re.FindStringSubmatch(string(lines))
 				containerID := submatches[1]

--- a/context.go
+++ b/context.go
@@ -171,7 +171,7 @@ func GetCurrentContainerID() string {
 	for scanner.Scan() {
 		_, lines, err := bufio.ScanLines([]byte(scanner.Text()), true)
 		if err == nil {
-			re := regexp.MustCompilePOSIX("/docker-([[:alnum:]]{64}).scope$")
+			re := regexp.MustCompilePOSIX("/docker/([[:alnum:]]{64})$")
 			if re.MatchString(string(lines)) {
 				submatches := re.FindStringSubmatch(string(lines))
 				containerID := submatches[1]

--- a/context.go
+++ b/context.go
@@ -2,7 +2,6 @@ package dockergen
 
 import (
 	"bufio"
-	"log"
 	"os"
 	"regexp"
 	"sync"

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,13 @@
+package dockergen
+
+import (
+	"testing"
+)
+
+func TestGetCurrentContainerID(t *testing.T) {
+	currentContainerID := GetCurrentContainerID()
+
+	if len(currentContainerID) != 64 {
+		t.Fail()
+	}
+}

--- a/context_test.go
+++ b/context_test.go
@@ -7,7 +7,7 @@ import (
 func TestGetCurrentContainerID(t *testing.T) {
 	currentContainerID := GetCurrentContainerID()
 
-	if len(currentContainerID) != 64 {
+	if len(currentContainerID) != 0 && len(currentContainerID) != 64 {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
Add CurrentContainerID into Docker struct. This improvement allow the possibility to compare current container networks and others containers networks.

@md5 I watched your comments and I edited my code to propose a best version.

Linked with https://github.com/jwilder/nginx-proxy/pull/337