### PR TITLE
allow dotted map keys in deepGet

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
 
 #### Functions
 
+`$fieldPath` arguments: A field path expression is a dot-delimited list of map keys or struct member names specifying the path from container to a nested value, which must be a string. Dots in map keys can be escaped with a backslash, which must also be escaped, such as `"my\\.dotted\\.key"`.
+
 * *`closest $array $value`*: Returns the longest matching substring in `$array` that matches `$value`
 * *`coalesce ...`*: Returns the first non-nil argument.
 * *`contains $map $key`*: Returns `true` if `$map` contains `$key`. Takes maps from `string` to `string`.
@@ -345,7 +347,7 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
 * *`dir $path`*: Returns an array of filenames in the specified `$path`.
 * *`exists $path`*: Returns `true` if `$path` refers to an existing file or directory. Takes a string.
 * *`first $array`*: Returns the first value of an array or nil if the arry is nil or empty.
-* *`groupBy $containers $fieldPath`*: Groups an array of `RuntimeContainer` instances based on the values of a field path expression `$fieldPath`. A field path expression is a dot-delimited list of map keys or struct member names specifying the path from container to a nested value, which must be a string. Returns a map from the value of the field path expression to an array of containers having that value. Containers that do not have a value for the field path in question are omitted.
+* *`groupBy $containers $fieldPath`*: Groups an array of `RuntimeContainer` instances based on the values of a field path expression `$fieldPath`. Returns a map from the value of the field path expression to an array of containers having that value. Containers that do not have a value for the field path in question are omitted.
 * *`groupByKeys $containers $fieldPath`*: Returns the same as `groupBy` but only returns the keys of the map.
 * *`groupByMulti $containers $fieldPath $sep`*: Like `groupBy`, but the string value specified by `$fieldPath` is first split by `$sep` into a list of strings. A container whose `$fieldPath` value contains a list of strings will show up in the map output under each of those strings.
 * *`hasPrefix $prefix $string`*: Returns whether `$prefix` is a prefix of `$string`.
@@ -354,7 +356,7 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
 * *`json $value`*: Returns the JSON representation of `$value` as a `string`.
 * *`keys $map`*: Returns the keys from `$map`. If `$map` is `nil`, a `nil` is returned. If `$map` is not a `map`, an error will be thrown.
 * *`last $array`*: Returns the last value of an array.
-* *`parseBool $string`*: parseBool returns the boolean value represented by the string. It accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False. Any other value returns an error. Alias for [`strconv.ParseBool`](http://golang.org/pkg/strconv/#ParseBool) 
+* *`parseBool $string`*: parseBool returns the boolean value represented by the string. It accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False. Any other value returns an error. Alias for [`strconv.ParseBool`](http://golang.org/pkg/strconv/#ParseBool)
 * *`replace $string $old $new $count`*: Replaces up to `$count` occurences of `$old` with `$new` in `$string`. Alias for [`strings.Replace`](http://golang.org/pkg/strings/#Replace)
 * *`sha1 $string`*: Returns the hexadecimal representation of the SHA1 hash of `$string`.
 * *`split $string $sep`*: Splits `$string` into a slice of substrings delimited by `$sep`. Alias for [`strings.Split`](http://golang.org/pkg/strings/#Split)

--- a/reflect.go
+++ b/reflect.go
@@ -18,6 +18,20 @@ func stripPrefix(s, prefix string) string {
 	return path
 }
 
+func joinDots(parts []string) (string, []string) {
+	part := parts[0]
+	parts = parts[1:]
+	for {
+		if part[len(part)-1] == '\\' && len(parts) > 0 {
+			part = part[0:len(part)-1] + "." + parts[0]
+			parts = parts[1:]
+			continue
+		}
+		break
+	}
+	return part, parts
+}
+
 func deepGet(item interface{}, path string) interface{} {
 	if path == "" {
 		return item
@@ -28,16 +42,17 @@ func deepGet(item interface{}, path string) interface{} {
 	itemValue := reflect.ValueOf(item)
 
 	if len(parts) > 0 {
+		part, parts := joinDots(parts)
 		switch itemValue.Kind() {
 		case reflect.Struct:
-			fieldValue := itemValue.FieldByName(parts[0])
+			fieldValue := itemValue.FieldByName(part)
 			if fieldValue.IsValid() {
-				return deepGet(fieldValue.Interface(), strings.Join(parts[1:], "."))
+				return deepGet(fieldValue.Interface(), strings.Join(parts, "."))
 			}
 		case reflect.Map:
-			mapValue := itemValue.MapIndex(reflect.ValueOf(parts[0]))
+			mapValue := itemValue.MapIndex(reflect.ValueOf(part))
 			if mapValue.IsValid() {
-				return deepGet(mapValue.Interface(), strings.Join(parts[1:], "."))
+				return deepGet(mapValue.Interface(), strings.Join(parts, "."))
 			}
 		default:
 			log.Printf("can't group by %s (value %v, kind %s)\n", path, itemValue, itemValue.Kind())

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -59,3 +59,37 @@ func TestDeepGetMap(t *testing.T) {
 		t.Errorf("expected: %s. got: %s", "value", value)
 	}
 }
+
+func TestDeepGetMapWithDots(t *testing.T) {
+	item := RuntimeContainer{
+		Labels: map[string]string{
+			"some.dot.value": "value",
+		},
+	}
+	value := deepGet(item, "Labels.some\\.dot\\.value")
+	if _, ok := value.(string); !ok {
+		t.Errorf("expected: %#v. got: %#v", "value", value)
+	}
+
+	if value != "value" {
+		t.Errorf("expected: %s. got: %s", "value", value)
+	}
+}
+
+func TestDeepGetMapWithDotsThenMore(t *testing.T) {
+	item := RuntimeContainer{
+		Volumes: map[string]Volume{
+			"some.dot.value": Volume{
+				Path: "value",
+			},
+		},
+	}
+	value := deepGet(item, "Volumes.some\\.dot\\.value.Path")
+	if _, ok := value.(string); !ok {
+		t.Errorf("expected: %#v. got: %#v", "value", value)
+	}
+
+	if value != "value" {
+		t.Errorf("expected: %s. got: %s", "value", value)
+	}
+}


### PR DESCRIPTION
The primary use case here is to allow calling groupBy with a label,
by convention labels are prefixed with a reverse domain name such as
"com.docker.compose".

I'm not in love with the syntax, I'm open to suggestions on what to do there. Technically any syntax is not 100% backwards compatible, since a map key could be any arbitrary string. I'm hoping a backslash at the end of a map key is unusual enough that this is OK.