### PR TITLE
Documentation: fix signal number/name mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ watch = true
 wait = "500ms:2s"
 
 [config.NotifyContainers]
-nginx = 1  # 1 is a signal number to be sent; here SIGINT
+nginx = 1  # 1 is a signal number to be sent; here SIGHUP
 e75a60548dc9 = 1 # a key can be either container name (nginx) or ID
 ```
 

--- a/examples/docker-gen.cfg
+++ b/examples/docker-gen.cfg
@@ -14,5 +14,5 @@ template = "/etc/docker-gen/templates/nginx.tmpl"
 dest = "/etc/nginx/conf.d/default.conf"
 watch = true
 [config.NotifyContainers]
-nginx = 1  # 1 is a signal number to be sent; here SIGINT
+nginx = 1  # 1 is a signal number to be sent; here SIGHUP
 e75a60548dc9 = 1 # a key can be either container name (nginx) or ID


### PR DESCRIPTION
SIGHUP = 1
SIGINT = 2

See output of 'kill -l'