### PR TITLE
Extend CurrentContainerID Regexp

### DIFF
--- a/context.go
+++ b/context.go
@@ -169,7 +169,7 @@ func GetCurrentContainerID() string {
 	scanner := bufio.NewScanner(reader)
 	scanner.Split(bufio.ScanLines)
 
-	regex := "/docker/([[:alnum:]]{64})$"
+	regex := "/docker[/-]([[:alnum:]]{64})(\\.scope)?$"
 	re := regexp.MustCompilePOSIX(regex)
 
 	for scanner.Scan() {


### PR DESCRIPTION
From #158, the format of /proc/self/cgroups depends on distro/setup. Seems like systemd uses docker-\<id\>.scope, others use docker/\<id\>.  From Fedora 23 (.Docker.CurrentContainerID always reports ""):
```
11:pids:/
10:devices:/system.slice/docker-9b98bb265ea4c149d9a786380dd07716d341c3e925f2616040c6cd9ac8c4b75c.scope
9:perf_event:/system.slice/docker-9b98bb265ea4c149d9a786380dd07716d341c3e925f2616040c6cd9ac8c4b75c.scope
8:blkio:/system.slice/docker-9b98bb265ea4c149d9a786380dd07716d341c3e925f2616040c6cd9ac8c4b75c.scope
7:cpu,cpuacct:/system.slice/docker-9b98bb265ea4c149d9a786380dd07716d341c3e925f2616040c6cd9ac8c4b75c.scope
6:cpuset:/system.slice/docker-9b98bb265ea4c149d9a786380dd07716d341c3e925f2616040c6cd9ac8c4b75c.scope
5:hugetlb:/system.slice/docker-9b98bb265ea4c149d9a786380dd07716d341c3e925f2616040c6cd9ac8c4b75c.scope
4:net_cls,net_prio:/system.slice/docker-9b98bb265ea4c149d9a786380dd07716d341c3e925f2616040c6cd9ac8c4b75c.scope
3:freezer:/system.slice/docker-9b98bb265ea4c149d9a786380dd07716d341c3e925f2616040c6cd9ac8c4b75c.scope
2:memory:/system.slice/docker-9b98bb265ea4c149d9a786380dd07716d341c3e925f2616040c6cd9ac8c4b75c.scope
1:name=systemd:/system.slice/docker-9b98bb265ea4c149d9a786380dd07716d341c3e925f2616040c6cd9ac8c4b75c.scope
```
Same file on Ubuntu 14.04 (.Docker.CurrentContainerID is correct):
```
12:name=systemd:/
11:hugetlb:/docker/290f8214be3cb2026de41bc57c21893060bbb7eac2ef4b1470ddcc9b53725648
10:net_prio:/docker/290f8214be3cb2026de41bc57c21893060bbb7eac2ef4b1470ddcc9b53725648
9:perf_event:/docker/290f8214be3cb2026de41bc57c21893060bbb7eac2ef4b1470ddcc9b53725648
8:blkio:/docker/290f8214be3cb2026de41bc57c21893060bbb7eac2ef4b1470ddcc9b53725648
7:net_cls:/docker/290f8214be3cb2026de41bc57c21893060bbb7eac2ef4b1470ddcc9b53725648
6:freezer:/docker/290f8214be3cb2026de41bc57c21893060bbb7eac2ef4b1470ddcc9b53725648
5:devices:/docker/290f8214be3cb2026de41bc57c21893060bbb7eac2ef4b1470ddcc9b53725648
4:memory:/docker/290f8214be3cb2026de41bc57c21893060bbb7eac2ef4b1470ddcc9b53725648
3:cpuacct:/docker/290f8214be3cb2026de41bc57c21893060bbb7eac2ef4b1470ddcc9b53725648
2:cpu:/docker/290f8214be3cb2026de41bc57c21893060bbb7eac2ef4b1470ddcc9b53725648
1:cpuset:/docker/290f8214be3cb2026de41bc57c21893060bbb7eac2ef4b1470ddcc9b53725648
```
Both use Docker 1.9.1.  For the time being, I recommend having the regexp accept both unless there's a better way to get the current container ID.