### PR TITLE
Make dirList return empty slice instead of error

### DIFF
--- a/template.go
+++ b/template.go
@@ -368,7 +368,8 @@ func dirList(path string) ([]string, error) {
 	names := []string{}
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
-		return names, err
+		log.Printf("Template error: %v", err)
+		return names, nil
 	}
 	for _, f := range files {
 		names = append(names, f.Name())


### PR DESCRIPTION
If directory does not exist.  Returning an error causes the template
it fail to render.