### PR TITLE
Add HostnameFull Variable to Template Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -88,6 +88,7 @@ type RuntimeContainer struct {
 	Gateway      string
 	Name         string
 	Hostname     string
+	HostnameFull string
 	Image        DockerImage
 	Env          map[string]string
 	Volumes      map[string]Volume

--- a/generator.go
+++ b/generator.go
@@ -378,6 +378,7 @@ func (g *generator) getContainers() ([]*RuntimeContainer, error) {
 			},
 			Name:         strings.TrimLeft(container.Name, "/"),
 			Hostname:     container.Config.Hostname,
+			HostnameFull: container.Config.Hostname + "." + container.Config.Domainname,
 			Gateway:      container.NetworkSettings.Gateway,
 			Addresses:    []Address{},
 			Networks:     []Network{},

--- a/generator_test.go
+++ b/generator_test.go
@@ -73,6 +73,7 @@ func TestGenerateFromEvents(t *testing.T) {
 			Args:    []string{},
 			Config: &docker.Config{
 				Hostname:     "docker-gen",
+				Domainname:   "tld",
 				AttachStdout: true,
 				AttachStderr: true,
 				Env:          []string{fmt.Sprintf("COUNTER=%d", counter)},


### PR DESCRIPTION
Add a variable called `HostnameFull` to the template context since the `Hostname` variable supplied by docker is missing the TLD (and the TLD supplied in Docker's `Domainname` variable isn't included in the context).

An alternative could be to add the `Domainname` variable instead, which would be closer to the information provided by Docker. The decision to provide `HostnameFull` is personal preference only.

Means you can do things like specify the hostname instead of having to specify `VIRTUAL_HOST` environment variables, or other crazy things like automatically create SSH login configs:

```
{{ range $i, $container := . }}
{{ range $j, $address := $container.Addresses }}
{{ if eq $address.Port "22" }}
Host {{ $container.Hostname }}
    HostName {{ $container.HostnameFull }}
    User docker
    IdentityFile ~/.ssh/id_rsa
    Port {{ $address.HostPort }}
{{ end }}
{{ end }}
{{ end }}
```