### PR TITLE
feat: Add "whereNot" function

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
 * *`trim $string`*: Removes whitespace from both sides of `$string`.
 * *`when $condition $trueValue $falseValue`*: Returns the `$trueValue` when the `$condition` is `true` and the `$falseValue` otherwise
 * *`where $items $fieldPath $value`*: Filters an array or slice based on the values of a field path expression `$fieldPath`. A field path expression is a dot-delimited list of map keys or struct member names specifying the path from container to a nested value. Returns an array of items having that value.
+* *`whereNot $items $fieldPath $value`*: Filters an array or slice based on the values of a field path expression `$fieldPath`. A field path expression is a dot-delimited list of map keys or struct member names specifying the path from container to a nested value. Returns an array of items **not** having that value.
 * *`whereExist $items $fieldPath`*: Like `where`, but returns only items where `$fieldPath` exists (is not nil).
 * *`whereNotExist $items $fieldPath`*: Like `where`, but returns only items where `$fieldPath` does not exist (is nil).
 * *`whereAny $items $fieldPath $sep $values`*: Like `where`, but the string value specified by `$fieldPath` is first split by `$sep` into a list of strings. The comparison value is a string slice with possible matches. Returns items which OR intersect these values.

--- a/template.go
+++ b/template.go
@@ -156,6 +156,13 @@ func where(entries interface{}, key string, cmp interface{}) (interface{}, error
 	})
 }
 
+// select entries where a key is not equal to a value
+func whereNot(entries interface{}, key string, cmp interface{}) (interface{}, error) {
+	return generalizedWhere("whereNot", entries, key, func(value interface{}) bool {
+		return !reflect.DeepEqual(value, cmp)
+	})
+}
+
 // selects entries where a key exists
 func whereExist(entries interface{}, key string) (interface{}, error) {
 	return generalizedWhere("whereExist", entries, key, func(value interface{}) bool {
@@ -442,6 +449,7 @@ func newTemplate(name string) *template.Template {
 		"trim":                   trim,
 		"when":                   when,
 		"where":                  where,
+		"whereNot":               whereNot,
 		"whereExist":             whereExist,
 		"whereNotExist":          whereNotExist,
 		"whereAny":               whereAny,

--- a/template_test.go
+++ b/template_test.go
@@ -351,6 +351,71 @@ func TestWhere(t *testing.T) {
 	tests.run(t, "where")
 }
 
+func TestWhereNot(t *testing.T) {
+	containers := []*RuntimeContainer{
+		&RuntimeContainer{
+			Env: map[string]string{
+				"VIRTUAL_HOST": "demo1.localhost",
+			},
+			ID: "1",
+			Addresses: []Address{
+				Address{
+					IP:    "172.16.42.1",
+					Port:  "80",
+					Proto: "tcp",
+				},
+			},
+		},
+		&RuntimeContainer{
+			Env: map[string]string{
+				"VIRTUAL_HOST": "demo2.localhost",
+			},
+			ID: "2",
+			Addresses: []Address{
+				Address{
+					IP:    "172.16.42.1",
+					Port:  "9999",
+					Proto: "tcp",
+				},
+			},
+		},
+		&RuntimeContainer{
+			Env: map[string]string{
+				"VIRTUAL_HOST": "demo3.localhost",
+			},
+			ID: "3",
+		},
+		&RuntimeContainer{
+			Env: map[string]string{
+				"VIRTUAL_HOST": "demo2.localhost",
+			},
+			ID: "4",
+		},
+	}
+
+	tests := templateTestList{
+		{`{{whereNot . "Env.VIRTUAL_HOST" "demo1.localhost" | len}}`, containers, `3`},
+		{`{{whereNot . "Env.VIRTUAL_HOST" "demo2.localhost" | len}}`, containers, `2`},
+		{`{{whereNot . "Env.VIRTUAL_HOST" "demo3.localhost" | len}}`, containers, `3`},
+		{`{{whereNot . "Env.NOEXIST" "demo3.localhost" | len}}`, containers, `4`},
+		{`{{whereNot .Addresses "Port" "80" | len}}`, containers[0], `0`},
+		{`{{whereNot .Addresses "Port" "80" | len}}`, containers[1], `1`},
+		{
+			`{{whereNot . "Value" 5 | len}}`,
+			[]struct {
+				Value int
+			}{
+				{Value: 5},
+				{Value: 3},
+				{Value: 5},
+			},
+			`1`,
+		},
+	}
+
+	tests.run(t, "whereNot")
+}
+
 func TestWhereExist(t *testing.T) {
 	containers := []*RuntimeContainer{
 		&RuntimeContainer{


### PR DESCRIPTION
Fix #261 

The goal is to filter out items not matching a property. My use case was to filter out non-published Addresses (ie. with `HostPort == ""`).

This PR allows me to solve it with:

```go
{{ $addresses := whereNot $container.Addresses "HostPort" "" }}
```