### PR TITLE
Added missing assignment to ECS match statement

### DIFF
--- a/context.go
+++ b/context.go
@@ -175,7 +175,7 @@ func GetCurrentContainerID() string {
 			strLines := string(lines)
 			if id := matchDockerCurrentContainerID(strLines); id != "" {
 				return id
-			} else if matchECSCurrentContainerID(strLines); id != "" {
+			} else if id:= matchECSCurrentContainerID(strLines); id != "" {
 				return id
 			}
 		}


### PR DESCRIPTION
Missing assignment meant that even though the regex matched the id, the if expression still failed and and empty container id is still returned.

This has been tested in a live ECS environment.

Completes fix for https://github.com/jwilder/docker-gen/issues/263.