### PR TITLE
Fixes missing assignment to id in context file conditions

### DIFF
--- a/context.go
+++ b/context.go
@@ -175,7 +175,7 @@ func GetCurrentContainerID() string {
 			strLines := string(lines)
 			if id := matchDockerCurrentContainerID(strLines); id != "" {
 				return id
-			} else if id:= matchECSCurrentContainerID(strLines); id != "" {
+			} else if id := matchECSCurrentContainerID(strLines); id != "" {
 				return id
 			}
 		}

--- a/context.go
+++ b/context.go
@@ -175,7 +175,7 @@ func GetCurrentContainerID() string {
 			strLines := string(lines)
 			if id := matchDockerCurrentContainerID(strLines); id != "" {
 				return id
-			} else if matchECSCurrentContainerID(strLines); id != "" {
+			} else if id:= matchECSCurrentContainerID(strLines); id != "" {
 				return id
 			}
 		}


### PR DESCRIPTION
Addition to the fix work in c9bde3f150f8c3f2ca0f2ca33ff921ea7f11aa03. This does not work in ECS itself.

This fix tested in ECS and with local docker and works in both cases.

Related to https://github.com/jwilder/docker-gen/issues/263.