### PR TITLE
Allow more notify and restart options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ dist-clean:
 	rm -f docker-gen-darwin-*.tar.gz
 
 dist: dist-clean
-	mkdir -p dist/alpine-linux/amd64 && GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -a -tags netgo -installsuffix netgo -o dist/alpine-linux/amd64/docker-gen ./cmd/docker-gen
+	mkdir -p dist/alpine-linux/amd64 && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -a -tags netgo -installsuffix netgo -o dist/alpine-linux/amd64/docker-gen ./cmd/docker-gen
 	mkdir -p dist/alpine-linux/arm64 && GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -a -tags netgo -installsuffix netgo -o dist/alpine-linux/arm64/docker-gen ./cmd/docker-gen
 	mkdir -p dist/alpine-linux/armhf && GOOS=linux GOARCH=arm GOARM=6 go build -ldflags "$(LDFLAGS)" -a -tags netgo -installsuffix netgo -o dist/alpine-linux/armhf/docker-gen ./cmd/docker-gen
 	mkdir -p dist/linux/amd64 && GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/linux/amd64/docker-gen ./cmd/docker-gen

--- a/README.md
+++ b/README.md
@@ -95,8 +95,13 @@ Options:
       run command after template is regenerated (e.g restart xyz)
   -notify-output
       log the output(stdout/stderr) of notify command
+  -notify-container container-ID
+      container to send a signal to
+  -notify-signal signal
+      signal to send to the -notify-container. -1 to call docker restart. Defaults to 1 aka. HUP.
+      All available signals available on the [dockerclient](https://github.com/fsouza/go-dockerclient/blob/01804dec8a84d0a77e63611f2b62d33e9bb2b64a/signal.go)
   -notify-sighup container-ID
-      send HUP signal to container.  Equivalent to 'docker kill -s HUP container-ID'
+      send HUP signal to container.  Equivalent to 'docker kill -s HUP container-ID', or `-notify-container container-ID -notify-signal 1`
   -only-exposed
       only include containers with exposed ports
   -only-published

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -10,33 +10,33 @@ import (
 
 	"github.com/BurntSushi/toml"
 	docker "github.com/fsouza/go-dockerclient"
-	"github.com/jwilder/docker-gen"
 )
 
 type stringslice []string
 
 var (
-	buildVersion            string
-	version                 bool
-	watch                   bool
-	wait                    string
-	notifyCmd               string
-	notifyOutput            bool
-	notifySigHUPContainerID string
-	onlyExposed             bool
-	onlyPublished           bool
-	includeStopped          bool
-	configFiles             stringslice
-	configs                 dockergen.ConfigFile
-	interval                int
-	keepBlankLines          bool
-	endpoint                string
-	tlsCert                 string
-	tlsKey                  string
-	tlsCaCert               string
-	tlsVerify               bool
-	tlsCertPath             string
-	wg                      sync.WaitGroup
+	buildVersion          string
+	version               bool
+	watch                 bool
+	wait                  string
+	notifyCmd             string
+	notifyOutput          bool
+	notifyContainerID     string
+	notifyContainerSignal int
+	onlyExposed           bool
+	onlyPublished         bool
+	includeStopped        bool
+	configFiles           stringslice
+	configs               dockergen.ConfigFile
+	interval              int
+	keepBlankLines        bool
+	endpoint              string
+	tlsCert               string
+	tlsKey                string
+	tlsCaCert             string
+	tlsVerify             bool
+	tlsCertPath           string
+	wg                    sync.WaitGroup
 )
 
 func (strings *stringslice) String() string {
@@ -95,8 +95,12 @@ func initFlags() {
 	flag.BoolVar(&includeStopped, "include-stopped", false, "include stopped containers")
 	flag.BoolVar(&notifyOutput, "notify-output", false, "log the output(stdout/stderr) of notify command")
 	flag.StringVar(&notifyCmd, "notify", "", "run command after template is regenerated (e.g `restart xyz`)")
-	flag.StringVar(&notifySigHUPContainerID, "notify-sighup", "",
+	flag.StringVar(&notifyContainerID, "notify-sighup", "",
 		"send HUP signal to container.  Equivalent to docker kill -s HUP `container-ID`")
+	flag.StringVar(&notifyContainerID, "notify-container", "",
+		"container to send a signal to")
+	flag.IntVar(&notifyContainerSignal, "notify-signal", int(docker.SIGHUP),
+		"signal to send to the notify-container. Defaults to SIGHUP")
 	flag.Var(&configFiles, "config", "config files with template directives. Config files will be merged if this option is specified multiple times.")
 	flag.IntVar(&interval, "interval", 0, "notify command interval (secs)")
 	flag.BoolVar(&keepBlankLines, "keep-blank-lines", false, "keep blank lines in the output file")
@@ -142,15 +146,15 @@ func main() {
 			Wait:             w,
 			NotifyCmd:        notifyCmd,
 			NotifyOutput:     notifyOutput,
-			NotifyContainers: make(map[string]docker.Signal),
+			NotifyContainers: make(map[string]int),
 			OnlyExposed:      onlyExposed,
 			OnlyPublished:    onlyPublished,
 			IncludeStopped:   includeStopped,
 			Interval:         interval,
 			KeepBlankLines:   keepBlankLines,
 		}
-		if notifySigHUPContainerID != "" {
-			config.NotifyContainers[notifySigHUPContainerID] = docker.SIGHUP
+		if notifyContainerID != "" {
+			config.NotifyContainers[notifyContainerID] = notifyContainerSignal
 		}
 		configs = dockergen.ConfigFile{
 			Config: []dockergen.Config{config}}

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	docker "github.com/fsouza/go-dockerclient"
+    "github.com/jwilder/docker-gen"
 )
 
 type stringslice []string

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	docker "github.com/fsouza/go-dockerclient"
-    "github.com/jwilder/docker-gen"
+	"github.com/jwilder/docker-gen"
 )
 
 type stringslice []string

--- a/config.go
+++ b/config.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fsouza/go-dockerclient"
 )
 
 type Config struct {
@@ -15,7 +14,7 @@ type Config struct {
 	Wait             *Wait
 	NotifyCmd        string
 	NotifyOutput     bool
-	NotifyContainers map[string]docker.Signal
+	NotifyContainers map[string]int
 	OnlyExposed      bool
 	OnlyPublished    bool
 	IncludeStopped   bool

--- a/config.go
+++ b/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"strings"
 	"time"
-
 )
 
 type Config struct {

--- a/generator.go
+++ b/generator.go
@@ -331,9 +331,17 @@ func (g *generator) sendSignalToContainer(config Config) {
 
 	for container, signal := range config.NotifyContainers {
 		log.Printf("Sending container '%s' signal '%v'", container, signal)
+
+		if signal == -1 {
+			if err := g.Client.RestartContainer(container, 10); err != nil {
+				log.Printf("Error sending restarting container: %s", err)
+			}
+			return
+		}
+
 		killOpts := docker.KillContainerOptions{
 			ID:     container,
-			Signal: signal,
+			Signal: docker.Signal(signal),
 		}
 		if err := g.Client.KillContainer(killOpts); err != nil {
 			log.Printf("Error sending signal to container: %s", err)


### PR DESCRIPTION
Added -notify-container and -notify-signal to expand on the -notify-sighup. 

Passing -1 to notify-signal is a special exception and calls docker restart on the container. 


note: I couldn't figure out how to get this to build on my windows dev machine. So it's possible there are some issues., hopefully travis will tell me if there are.