### PR TITLE
Enable multi-architecture docker image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.14-alpine as dockergen
 RUN apk add --no-cache git
 
 # Download the sources for the given version
-ENV VERSION 0.7.3
+ENV VERSION 0.7.4
 ADD https://github.com/jwilder/docker-gen/archive/${VERSION}.tar.gz sources.tar.gz
 
 # Move the sources into the right directory
@@ -21,7 +21,7 @@ LABEL maintainer="Jason Wilder <mail@jasonwilder.com>"
 
 RUN apk -U add openssl
 
-ENV VERSION 0.7.3
+ENV VERSION 0.7.4
 COPY --from=dockergen /go/src/github.com/jwilder/docker-gen/docker-gen /usr/local/bin/docker-gen
 ENV DOCKER_HOST unix:///tmp/docker.sock
 


### PR DESCRIPTION
Previously, the Dockerfile downloaded a 'docker-gen' binary during build time. This caused a problem as it hard-coded the `amd64` architecture for the image. 

This PR updates the Dockerfile to build the `docker-gen` executable from source instead of downloading a binary. This updated Dockerfile uses a multi-stage build [1]. 
The first stage downloads a source tarball from GitHub and produces a binary out of it. The second stage corresponds to the old Dockerfile, with the sole change being that is fetches the binary from the first stage instead of GitHub.

This has the advantage that the build process no longer assumes a certain architecture and enables building the image for any architecture that both the golang and alpine base images support. 
I've tested building this modified Dockerfile on both a linux desktop (`amd64`) and a raspberry pi (`armv7`). I've also used the built image to successfully test a modified architecture independent variant of [2] successfully, I will make a similar PR there soon as well.  
Together with actually publishing multi-architecture images to DockerHub this PR fixes #304 and #318. 

This PR also bumps the version being built to 0.7.4, as 0.7.3 can no longer be compiled from source. 

[1] https://docs.docker.com/develop/develop-images/multistage-build/
[2] https://github.com/nginx-proxy/nginx-proxy

