### PR TITLE
Fix docker-gen breaking on new docker version (See #335)

### DIFF
--- a/context.go
+++ b/context.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"regexp"
 	"sync"
-
+	"fmt"
 	"github.com/fsouza/go-dockerclient"
 )
 
@@ -159,24 +159,25 @@ type Docker struct {
 }
 
 func GetCurrentContainerID() string {
-	file, err := os.Open("/proc/self/cgroup")
+	filepaths := []string{"/proc/self/cgroup", "/proc/self/mountinfo"}
 
-	if err != nil {
-		return ""
-	}
-
-	reader := bufio.NewReader(file)
-	scanner := bufio.NewScanner(reader)
-	scanner.Split(bufio.ScanLines)
-
-	for scanner.Scan() {
-		_, lines, err := bufio.ScanLines([]byte(scanner.Text()), true)
-		if err == nil {
-			strLines := string(lines)
-			if id := matchDockerCurrentContainerID(strLines); id != "" {
-				return id
-			} else if id := matchECSCurrentContainerID(strLines); id != "" {
-				return id
+	for _, filepath := range filepaths {
+		file, err := os.Open(filepath)
+		if err != nil {
+			continue
+		}
+		reader := bufio.NewReader(file)
+		scanner := bufio.NewScanner(reader)
+		scanner.Split(bufio.ScanLines)
+		for scanner.Scan() {
+			_, lines, err := bufio.ScanLines([]byte(scanner.Text()), true)
+			if err == nil {
+				strLines := string(lines)
+				if id := matchDockerCurrentContainerID(strLines); id != "" {
+					return id
+				} else if id := matchECSCurrentContainerID(strLines); id != "" {
+					return id
+				}
 			}
 		}
 	}
@@ -185,7 +186,8 @@ func GetCurrentContainerID() string {
 }
 
 func matchDockerCurrentContainerID(lines string) string {
-	regex := "/docker[/-]([[:alnum:]]{64})(\\.scope)?$"
+	hostname := os.Getenv("HOSTNAME")
+	regex := fmt.Sprintf("(%s[[:alnum:]]{52})", hostname)
 	re := regexp.MustCompilePOSIX(regex)
 
 	if re.MatchString(lines) {


### PR DESCRIPTION
This PR is scanning for the full container ID by getting the short container id via `HOSTNAME`, then trying to fetch the rest of it in "/proc/self/cgroup" or "/proc/self/mountinfo".

So no breaking change to old versions of docker.

Alternative to #335

Note I did not tested on new docker, but I tested on old one and nothing break.