### PR TITLE
Lift restriction on the function contains

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
 
 * *`closest $array $value`*: Returns the longest matching substring in `$array` that matches `$value`
 * *`coalesce ...`*: Returns the first non-nil argument.
-* *`contains $map $key`*: Returns `true` if `$map` contains `$key`. Takes maps from `string` to `string`.
+* *`contains $map $key`*: Returns `true` if `$map` contains `$key`. Takes maps from `string` to any type.
 * *`dict $key $value ...`*: Creates a map from a list of pairs. Each `$key` value must be a `string`, but the `$value` can be any type (or `nil`). Useful for passing more than one value as a pipeline context to subtemplates.
 * *`dir $path`*: Returns an array of filenames in the specified `$path`.
 * *`exists $path`*: Returns `true` if `$path` refers to an existing file or directory. Takes a string.

--- a/template.go
+++ b/template.go
@@ -291,10 +291,20 @@ func intersect(l1, l2 []string) []string {
 	return keys
 }
 
-func contains(item map[string]string, key string) bool {
-	if _, ok := item[key]; ok {
-		return true
+func contains(input interface{}, key interface{}) bool {
+	if input == nil {
+		return false
 	}
+
+	val := reflect.ValueOf(input)
+	if val.Kind() == reflect.Map {
+		for _, k := range val.MapKeys() {
+			if k.Interface() == key {
+				return true
+			}
+		}
+	}
+
 	return false
 }
 

--- a/template_test.go
+++ b/template_test.go
@@ -33,7 +33,7 @@ func (tests templateTestList) run(t *testing.T, prefix string) {
 	}
 }
 
-func TestContains(t *testing.T) {
+func TestContainsString(t *testing.T) {
 	env := map[string]string{
 		"PORT": "1234",
 	}
@@ -43,6 +43,24 @@ func TestContains(t *testing.T) {
 	}
 
 	if contains(env, "MISSING") {
+		t.Fail()
+	}
+}
+
+func TestContainsInteger(t *testing.T) {
+	env := map[int]int{
+		42: 1234,
+	}
+
+	if !contains(env, 42) {
+		t.Fail()
+	}
+
+	if contains(env, "WRONG TYPE") {
+		t.Fail()
+	}
+
+	if contains(env, 24) {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
The function `contains` only allowed to check maps of the type `map[string]string`. This PR lifts this restriction and allows for arbitrary types to be used.