### PR TITLE
Have the Dockerfile build from the actual surrounding sources rather than downloading a hardcoded version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,27 @@
 # Build docker-gen from scratch
-FROM golang:1.14-alpine as dockergen
-RUN apk add --no-cache git
+FROM golang:1.16-alpine as go-builder
 
-# Download the sources for the given version
-ENV VERSION 0.7.5
-ADD https://github.com/jwilder/docker-gen/archive/${VERSION}.tar.gz sources.tar.gz
+ARG VERSION=master
 
-# Move the sources into the right directory
-RUN tar -xzf sources.tar.gz && \
-   mkdir -p /go/src/github.com/jwilder/ && \
-   mv docker-gen-* /go/src/github.com/jwilder/docker-gen
+WORKDIR /build
 
-# Install the dependencies and make the docker-gen executable
-WORKDIR /go/src/github.com/jwilder/docker-gen
-RUN CGO_ENABLED=0 go build -ldflags "-X main.buildVersion=${VERSION}" ./cmd/docker-gen
+# Install the dependencies
+COPY . .
+RUN go mod download -json
 
-FROM alpine:latest
+# Build the docker-gen executable
+RUN CGO_ENABLED=0 go build -ldflags "-X main.buildVersion=${VERSION}" -o docker-gen ./cmd/docker-gen
+
+FROM alpine:3.13
+
 LABEL maintainer="Jason Wilder <mail@jasonwilder.com>"
 
-RUN apk -U add openssl
-
-ENV VERSION 0.7.5
-COPY --from=dockergen /go/src/github.com/jwilder/docker-gen/docker-gen /usr/local/bin/docker-gen
 ENV DOCKER_HOST unix:///tmp/docker.sock
 
+# Install packages required by the image
+RUN apk add --no-cache --virtual .bin-deps openssl
+
+# Install docker-gen from build stage
+COPY --from=go-builder /build/docker-gen /usr/local/bin/docker-gen
 
 ENTRYPOINT ["/usr/local/bin/docker-gen"]


### PR DESCRIPTION
While I understand the rationale for downloading a hard coded version back when building the Go binary using multi stage Dockerfile wasn't an option, I think it's not relevant anymore and that the Dockerfile should build an image corresponding to the surrounding sources. We're currently in a strange situation where the project's Dockerfile potentially builds an image that use codes dating from a handful of commits back.

Having tagged versions of the container derived from git tags should happen through the CI  instead (either GitHub Actions of DockerHub's autobuild). The version can still be passed to `go build -X main.buildVersion` using the `VERSION` build `ARG`.

The resultant image has been tested with nginx-proxy and is working.