### PR TITLE
Build multi arch images on GitHub Actions and push to DockerHub

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,62 @@
+name: DockerHub
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1'
+  push:
+    branches:
+      - master
+    tags:
+      - '*.*.*'
+    paths:
+      - '.dockerignore'
+      - '.github/workflows/dockerhub.yml'
+      - 'Dockerfile'
+      - 'go.mod'
+      - 'go.sum'
+      - '**.go'
+
+jobs:
+  multiarch-build:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+        
+      - name: Get Docker tags
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          images: jwilder/docker-gen
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
As proposed in https://github.com/jwilder/docker-gen/pull/346#issuecomment-817115037, this PR adds a GitHub Actions workflow that build multi arch images of **jwilder/docker-gen** and push them to DockerHub.

For this PR to work, in addition to enabling GitHub Actions, two secrets need to be added to the repo:
`DOCKERHUB_USERNAME`: the name of DockerHub account that has push rights to **jwilder/docker-gen**
`DOCKERHUB_TOKEN`: a DockerHub access token for the `DOCKERHUB_USERNAME` account

The workflow is triggered:
- on push to the master branch
- on creation of a new `x.y.z` semver tag
- on schedule every Monday at 00:00 UTC

It can also be triggered manually thanks to `workflow_dispatch`

The images created from new Git tags are tagged as `:{{major}}.{{minor}}` and `:{{major}}.{{minor}}.{{patch}}`, ie a new `0.7.6` tag would push `jwilder/docker-gen:0.7.6` and `jwilder/docker-gen:0.7` to Dockerhub.

Every newly built image is also pushed as `latest`.