### PR TITLE
Add Debian based image

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -19,16 +19,20 @@ on:
 
 jobs:
   multiarch-build:
+    strategy:
+      matrix:
+        base: [alpine, debian]
     runs-on: ubuntu-latest
+    
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
         
-      - name: Get Docker tags
-        id: docker_meta
+      - name: Get Docker tags for Alpine based image
+        if: ${{ matrix.base == 'alpine' }}
+        id: docker_meta_alpine
         uses: crazy-max/ghaction-docker-meta@v2
         with:
           images: |
@@ -38,6 +42,20 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+      
+      - name: Get Docker tags for Debian based image
+        if: ${{ matrix.base == 'debian' }}
+        id: docker_meta_debian
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          images: |
+            nginxproxy/docker-gen
+            jwilder/docker-gen
+          tags: |
+            type=semver,suffix=-debian,pattern={{version}}
+            type=semver,suffix=-debian,pattern={{major}}.{{minor}}
+            type=raw,value=debian,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+          flavor: latest=false
 
       - name: Retrieve version
         run: echo "VERSION=$(git describe --tags)" >> $GITHUB_ENV
@@ -54,15 +72,33 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
-      - name: Build and push
-        id: docker_build
+      - name: Build and push the Alpine based image
+        if: ${{ matrix.base == 'alpine' }}
+        id: docker_build_alpine
         uses: docker/build-push-action@v2
         with:
           build-args: VERSION=${{ env.VERSION }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
+          tags: ${{ steps.docker_meta_alpine.outputs.tags }}
+          labels: ${{ steps.docker_meta_alpine.outputs.labels }}
+      
+      - name: Build and push the Debian based image
+        if: ${{ matrix.base == 'debian' }}
+        id: docker_build_debian
+        uses: docker/build-push-action@v2
+        with:
+          build-args: VERSION=${{ env.VERSION }}
+          file: Dockerfile.debian
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: ${{ steps.docker_meta_debian.outputs.tags }}
+          labels: ${{ steps.docker_meta_debian.outputs.labels }}
 
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Alpine based image digest
+        if: ${{ matrix.base == 'alpine' }}
+        run: echo ${{ steps.docker_build_alpine.outputs.digest }}
+      
+      - name: Debian based image digest
+        if: ${{ matrix.base == 'debian' }}
+        run: echo ${{ steps.docker_build_debian.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ WORKDIR /build
 
 # Install the dependencies
 COPY . .
-RUN go mod download -json
+RUN go mod download
 
 # Build the docker-gen executable
-RUN CGO_ENABLED=0 go build -ldflags "-X main.buildVersion=${VERSION}" -o docker-gen ./cmd/docker-gen
+RUN GOOS=linux CGO_ENABLED=0 go build -ldflags "-X main.buildVersion=${VERSION}" -o docker-gen ./cmd/docker-gen
 
 FROM alpine:3.13
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,30 @@
+# Build docker-gen from scratch
+FROM golang:1.17.5 as go-builder
+
+ARG VERSION=main
+
+WORKDIR /build
+
+# Install the dependencies
+COPY . .
+RUN go mod download
+
+# Build the docker-gen executable
+RUN GOOS=linux go build -ldflags "-X main.buildVersion=${VERSION}" -o docker-gen ./cmd/docker-gen
+
+FROM debian:11-slim
+
+LABEL maintainer="Jason Wilder <mail@jasonwilder.com>"
+
+ENV DOCKER_HOST unix:///tmp/docker.sock
+
+# Install packages required by the image
+RUN apt-get update \
+    && apt-get install -y -q --no-install-recommends openssl \
+    && apt-get clean \
+    && rm -r /var/lib/apt/lists/*
+
+# Install docker-gen from build stage
+COPY --from=go-builder /build/docker-gen /usr/local/bin/docker-gen
+
+ENTRYPOINT ["/usr/local/bin/docker-gen"]


### PR DESCRIPTION
This new image is intended to be used directly by `nginxproxy/nginx-proxy`'s Dockerfile (instead of building `docker-gen` locally) in the near future.