### PR TITLE
feat: expose network aliases to templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ type Address struct {
 type Network struct {
     IP                  string
     Name                string
+    Aliases             []string
     Gateway             string
     EndpointID          string
     IPv6Gateway         string

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -55,6 +55,7 @@ func SetDockerEnv(d *docker.Env) {
 type Network struct {
 	IP                  string
 	Name                string
+	Aliases             []string
 	Gateway             string
 	EndpointID          string
 	IPv6Gateway         string

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -460,6 +460,7 @@ func (g *generator) getContainers(config config.Config) ([]*context.RuntimeConta
 			network := context.Network{
 				IP:                  v.IPAddress,
 				Name:                k,
+				Aliases:             append([]string{}, v.Aliases...),
 				Gateway:             v.Gateway,
 				EndpointID:          v.EndpointID,
 				IPv6Gateway:         v.IPv6Gateway,


### PR DESCRIPTION
## Summary

A container's per-network aliases (`docker.ContainerNetwork.Aliases`) are already returned by the docker client but were discarded when building the template context. This exposes them as a new `Aliases []string` field on the `Network` struct, so templates can generate DNS / vhost config keyed on a container's aliases within a network.

The data is already fetched, so this is a pure additive passthrough — no behavior change for existing templates.

## Changes

- `internal/context/context.go`: add `Aliases []string` to the `Network` struct.
- `internal/generator/generator.go`: populate it from `NetworkSettings.Networks` (`v.Aliases`).
- `README.md`: document the new field in the "Emit Structure" section.

## Notes

- Docker may include auto-generated entries (e.g. the short container ID and the hostname) alongside user-defined aliases, so template authors may want to filter the list for their use case.
- This mirrors the existing `Network` / `Volume` / `Mount` mappings in `getContainers`, none of which currently have dedicated unit tests, so none was added here. Happy to add one (e.g. by extracting a small mapping helper) if you'd prefer coverage.

Fixes #171
