### PR TITLE
fix: avoid panic on nil container Config/NetworkSettings/HostConfig

### DIFF
--- a/internal/context/address.go
+++ b/internal/context/address.go
@@ -18,30 +18,35 @@ type Address struct {
 }
 
 func renderAddress(container *docker.Container, port docker.Port) Address {
-	return Address{
-		IP:           container.NetworkSettings.IPAddress,
-		IP6LinkLocal: container.NetworkSettings.LinkLocalIPv6Address,
-		IP6Global:    container.NetworkSettings.GlobalIPv6Address,
-		Port:         port.Port(),
-		Proto:        port.Proto(),
+	address := Address{
+		Port:  port.Port(),
+		Proto: port.Proto(),
 	}
+	if container.NetworkSettings != nil {
+		address.IP = container.NetworkSettings.IPAddress
+		address.IP6LinkLocal = container.NetworkSettings.LinkLocalIPv6Address
+		address.IP6Global = container.NetworkSettings.GlobalIPv6Address
+	}
+	return address
 }
 
 func GetContainerAddresses(container *docker.Container) []Address {
 	addresses := []Address{}
 
-	for port, bindings := range container.NetworkSettings.Ports {
-		address := renderAddress(container, port)
+	if container.NetworkSettings != nil {
+		for port, bindings := range container.NetworkSettings.Ports {
+			address := renderAddress(container, port)
 
-		if len(bindings) > 0 {
-			address.HostPort = bindings[0].HostPort
-			address.HostIP = bindings[0].HostIP
+			if len(bindings) > 0 {
+				address.HostPort = bindings[0].HostPort
+				address.HostIP = bindings[0].HostIP
+			}
+
+			addresses = append(addresses, address)
 		}
-
-		addresses = append(addresses, address)
 	}
 
-	if len(addresses) == 0 {
+	if len(addresses) == 0 && container.Config != nil {
 		// internal docker network has empty 'container.NetworkSettings.Ports'
 		for port := range container.Config.ExposedPorts {
 			address := renderAddress(container, port)

--- a/internal/context/address_test.go
+++ b/internal/context/address_test.go
@@ -161,3 +161,16 @@ func TestGetContainerAddressesSorted(t *testing.T) {
 	}
 	assert.Equal(t, []string{"80", "443", "8080"}, ports)
 }
+
+func TestGetContainerAddressesNilNetworkSettings(t *testing.T) {
+	testContainer := &docker.Container{
+		Config:          &docker.Config{ExposedPorts: map[docker.Port]struct{}{}},
+		NetworkSettings: nil,
+	}
+	assert.Empty(t, GetContainerAddresses(testContainer))
+}
+
+func TestGetContainerAddressesNilStructs(t *testing.T) {
+	testContainer := &docker.Container{Config: nil, NetworkSettings: nil}
+	assert.Empty(t, GetContainerAddresses(testContainer))
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -431,7 +431,21 @@ func (g *generator) getContainers(config config.Config) ([]*context.RuntimeConta
 			continue
 		}
 
-		registry, repository, tag := dockerclient.SplitDockerImage(container.Config.Image)
+		// Inspect may return nil pointers for these structs; copy into zero values to avoid a panic.
+		var containerConfig docker.Config
+		if container.Config != nil {
+			containerConfig = *container.Config
+		}
+		var containerNetSettings docker.NetworkSettings
+		if container.NetworkSettings != nil {
+			containerNetSettings = *container.NetworkSettings
+		}
+		var containerHostConfig docker.HostConfig
+		if container.HostConfig != nil {
+			containerHostConfig = *container.HostConfig
+		}
+
+		registry, repository, tag := dockerclient.SplitDockerImage(containerConfig.Image)
 		runtimeContainer := &context.RuntimeContainer{
 			ID:      container.ID,
 			Created: container.Created,
@@ -447,24 +461,24 @@ func (g *generator) getContainers(config config.Config) ([]*context.RuntimeConta
 				},
 			},
 			Name:         strings.TrimLeft(container.Name, "/"),
-			Hostname:     container.Config.Hostname,
-			Gateway:      container.NetworkSettings.Gateway,
-			NetworkMode:  container.HostConfig.NetworkMode,
+			Hostname:     containerConfig.Hostname,
+			Gateway:      containerNetSettings.Gateway,
+			NetworkMode:  containerHostConfig.NetworkMode,
 			Addresses:    []context.Address{},
 			Networks:     []context.Network{},
 			Env:          make(map[string]string),
 			Volumes:      make(map[string]context.Volume),
 			Node:         context.SwarmNode{},
 			Labels:       make(map[string]string),
-			IP:           container.NetworkSettings.IPAddress,
-			IP6LinkLocal: container.NetworkSettings.LinkLocalIPv6Address,
-			IP6Global:    container.NetworkSettings.GlobalIPv6Address,
+			IP:           containerNetSettings.IPAddress,
+			IP6LinkLocal: containerNetSettings.LinkLocalIPv6Address,
+			IP6Global:    containerNetSettings.GlobalIPv6Address,
 		}
 
-		adresses := context.GetContainerAddresses(container)
-		runtimeContainer.Addresses = append(runtimeContainer.Addresses, adresses...)
+		addresses := context.GetContainerAddresses(container)
+		runtimeContainer.Addresses = append(runtimeContainer.Addresses, addresses...)
 
-		for k, v := range container.NetworkSettings.Networks {
+		for k, v := range containerNetSettings.Networks {
 			network := context.Network{
 				IP:                  v.IPAddress,
 				Name:                k,
@@ -511,8 +525,8 @@ func (g *generator) getContainers(config config.Config) ([]*context.RuntimeConta
 			})
 		}
 
-		runtimeContainer.Env = utils.SplitKeyValueSlice(container.Config.Env)
-		runtimeContainer.Labels = container.Config.Labels
+		runtimeContainer.Env = utils.SplitKeyValueSlice(containerConfig.Env)
+		runtimeContainer.Labels = containerConfig.Labels
 		containers = append(containers, runtimeContainer)
 	}
 	return containers, nil

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -246,3 +246,57 @@ func TestSortNetworks(t *testing.T) {
 		})
 	}
 }
+
+func TestGetContainersNilStructs(t *testing.T) {
+	// A container inspected with nil Config/NetworkSettings/HostConfig must not panic (#227).
+	log.SetOutput(io.Discard)
+	containerID := "abc123def4567890"
+
+	server, _ := dockertest.NewServer("127.0.0.1:0", nil, nil)
+	server.CustomHandler("/info", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"Containers":1,"Images":1,"NFd":11,"NGoroutines":21}`))
+	}))
+	server.CustomHandler("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"Version":"19.03.12","Os":"Linux","GoVersion":"go1.13.14","Arch":"amd64","ApiVersion":"1.40"}`))
+	}))
+	server.CustomHandler("/networks", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("[]"))
+	}))
+	server.CustomHandler("/containers/json", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]docker.APIContainers{{ID: containerID, Names: []string{"/nil-test"}}})
+	}))
+	server.CustomHandler(fmt.Sprintf("/containers/%s/json", containerID), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(docker.Container{
+			ID:              containerID,
+			Name:            "/nil-test",
+			Config:          nil,
+			HostConfig:      nil,
+			NetworkSettings: nil,
+		})
+	}))
+
+	serverURL := fmt.Sprintf("tcp://%s", strings.TrimRight(strings.TrimPrefix(server.URL(), "http://"), "/"))
+	client, err := dockerclient.NewDockerClient(serverURL, false, "", "", "")
+	if err != nil {
+		t.Fatalf("failed to create client: %s", err)
+	}
+	client.SkipServerVersionCheck = true
+
+	apiVersion, err := client.Version()
+	if err != nil {
+		t.Fatalf("failed to retrieve version: %s", err)
+	}
+	context.SetDockerEnv(apiVersion)
+
+	g := &generator{Client: client, Endpoint: serverURL}
+	containers, err := g.getContainers(config.Config{})
+	assert.NoError(t, err)
+	assert.Len(t, containers, 1)
+	assert.Equal(t, containerID, containers[0].ID)
+	assert.Equal(t, "nil-test", containers[0].Name)
+	assert.Empty(t, containers[0].Hostname)
+	assert.Empty(t, containers[0].NetworkMode)
+	assert.Empty(t, containers[0].IP)
+	assert.Empty(t, containers[0].Addresses)
+	assert.Empty(t, containers[0].Networks)
+}


### PR DESCRIPTION
`getContainers` dereferenced `container.Config`, `container.NetworkSettings` and `container.HostConfig` (and `GetContainerAddresses`/`renderAddress` dereferenced `NetworkSettings`/`Config`) without nil checks. Inspect can return these as nil for some containers/daemons, causing a panic that aborts generation for every container.

This copies each pointer into a zero value when nil, so the container is still emitted with its ID/Name and empty fields instead of crashing, and makes `GetContainerAddresses` nil-safe (it's exported and used elsewhere). `State` is a value (not a pointer) and ranging nil maps/slices is safe, so those are left unchanged.

Adds nil-struct tests for `GetContainerAddresses` and `getContainers`.

Fixes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)
