### PR TITLE
ci: disable docker/build-push-action caching

### DIFF
--- a/.github/workflows/build-publish-dispatch.yml
+++ b/.github/workflows/build-publish-dispatch.yml
@@ -76,8 +76,6 @@ jobs:
           provenance: mode=max
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Docker image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -93,8 +93,6 @@ jobs:
           provenance: mode=max
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Docker image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
`docker/build-push-action` cache never ever appear to work and consume time.