### PR TITLE
fix: don't treat image namespace as registry

### DIFF
--- a/internal/dockerclient/docker_cli.go
+++ b/internal/dockerclient/docker_cli.go
@@ -119,20 +119,18 @@ func parseHost(addr string) (string, string, error) {
 }
 
 func SplitDockerImage(img string) (string, string, string) {
-	index := 0
-	repository := img
 	var registry, tag string
-	if strings.Contains(img, "/") {
-		separator := strings.Index(img, "/")
-		registry = img[index:separator]
-		index = separator + 1
-		repository = img[index:]
+	repository := img
+	if i := strings.Index(img, "/"); i != -1 {
+		if first := img[:i]; strings.ContainsAny(first, ".:") || first == "localhost" {
+			registry = first
+			repository = img[i+1:]
+		}
 	}
 
-	if strings.Contains(repository, ":") {
-		separator := strings.Index(repository, ":")
-		tag = repository[separator+1:]
-		repository = repository[0:separator]
+	if i := strings.Index(repository, ":"); i != -1 {
+		tag = repository[i+1:]
+		repository = repository[:i]
 	}
 
 	return registry, repository, tag

--- a/internal/dockerclient/docker_cli_test.go
+++ b/internal/dockerclient/docker_cli_test.go
@@ -184,6 +184,21 @@ func TestSplitDockerImageWithNamespacedRepositoryAndTag(t *testing.T) {
 	assert.Equal(t, "tianon/centos:7", dockerImage.String())
 }
 
+func TestSplitDockerImageWithLocalhostRegistryAndTag(t *testing.T) {
+	registry, repository, tag := SplitDockerImage("localhost/ubuntu:12.04")
+
+	assert.Equal(t, "localhost", registry)
+	assert.Equal(t, "ubuntu", repository)
+	assert.Equal(t, "12.04", tag)
+
+	dockerImage := context.DockerImage{
+		Registry:   registry,
+		Repository: repository,
+		Tag:        tag,
+	}
+	assert.Equal(t, "localhost/ubuntu:12.04", dockerImage.String())
+}
+
 func TestParseHostUnix(t *testing.T) {
 	proto, addr, err := parseHost("unix:///var/run/docker.sock")
 	assert.NoError(t, err)

--- a/internal/dockerclient/docker_cli_test.go
+++ b/internal/dockerclient/docker_cli_test.go
@@ -65,138 +65,117 @@ func TestUnixBadFormat(t *testing.T) {
 	}
 }
 
-func TestSplitDockerImageRepository(t *testing.T) {
-	registry, repository, tag := SplitDockerImage("ubuntu")
-
-	assert.Equal(t, "", registry)
-	assert.Equal(t, "ubuntu", repository)
-	assert.Equal(t, "", tag)
-
-	dockerImage := context.DockerImage{
-		Registry:   registry,
-		Repository: repository,
-		Tag:        tag,
-	}
-	assert.Equal(t, "ubuntu", dockerImage.String())
+type splitDockerImageResults struct {
+	registry   string
+	repository string
+	tag        string
 }
 
-func TestSplitDockerImageWithRegistry(t *testing.T) {
-	registry, repository, tag := SplitDockerImage("custom.registry/ubuntu")
+func assertSplitDockerImage(t *testing.T, image string, expected splitDockerImageResults) {
+	registry, repository, tag := SplitDockerImage(image)
 
-	assert.Equal(t, "custom.registry", registry)
-	assert.Equal(t, "ubuntu", repository)
-	assert.Equal(t, "", tag)
+	assert.Equal(t, expected.registry, registry)
+	assert.Equal(t, expected.repository, repository)
+	assert.Equal(t, expected.tag, tag)
 
 	dockerImage := context.DockerImage{
 		Registry:   registry,
 		Repository: repository,
 		Tag:        tag,
 	}
-	assert.Equal(t, "custom.registry/ubuntu", dockerImage.String())
+	assert.Equal(t, image, dockerImage.String())
 }
 
-func TestSplitDockerImageWithRegistryAndTag(t *testing.T) {
-	registry, repository, tag := SplitDockerImage("custom.registry/ubuntu:12.04")
+func TestSplitDockerImage(t *testing.T) {
+	t.Run("base image", func(t *testing.T) {
+		expected := splitDockerImageResults{
+			registry:   "",
+			repository: "ubuntu",
+			tag:        "",
+		}
+		assertSplitDockerImage(t, "ubuntu", expected)
+	})
 
-	assert.Equal(t, "custom.registry", registry)
-	assert.Equal(t, "ubuntu", repository)
-	assert.Equal(t, "12.04", tag)
+	t.Run("image with registry", func(t *testing.T) {
+		expected := splitDockerImageResults{
+			registry:   "custom.registry",
+			repository: "ubuntu",
+			tag:        "",
+		}
+		assertSplitDockerImage(t, "custom.registry/ubuntu", expected)
+	})
 
-	dockerImage := context.DockerImage{
-		Registry:   registry,
-		Repository: repository,
-		Tag:        tag,
-	}
-	assert.Equal(t, "custom.registry/ubuntu:12.04", dockerImage.String())
-}
+	t.Run("image with tag", func(t *testing.T) {
+		expected := splitDockerImageResults{
+			registry:   "",
+			repository: "ubuntu",
+			tag:        "12.04",
+		}
+		assertSplitDockerImage(t, "ubuntu:12.04", expected)
+	})
 
-func TestSplitDockerImageWithRepositoryAndTag(t *testing.T) {
-	registry, repository, tag := SplitDockerImage("ubuntu:12.04")
+	t.Run("image with registry and tag", func(t *testing.T) {
+		expected := splitDockerImageResults{
+			registry:   "custom.registry",
+			repository: "ubuntu",
+			tag:        "12.04",
+		}
+		assertSplitDockerImage(t, "custom.registry/ubuntu:12.04", expected)
+	})
 
-	assert.Equal(t, "", registry)
-	assert.Equal(t, "ubuntu", repository)
-	assert.Equal(t, "12.04", tag)
+	t.Run("image with localhost registry and tag", func(t *testing.T) {
+		expected := splitDockerImageResults{
+			registry:   "localhost",
+			repository: "ubuntu",
+			tag:        "12.04",
+		}
+		assertSplitDockerImage(t, "localhost/ubuntu:12.04", expected)
+	})
 
-	dockerImage := context.DockerImage{
-		Registry:   registry,
-		Repository: repository,
-		Tag:        tag,
-	}
-	assert.Equal(t, "ubuntu:12.04", dockerImage.String())
-}
+	t.Run("image with localhost registry on custom port and tag", func(t *testing.T) {
+		expected := splitDockerImageResults{
+			registry:   "localhost:8888",
+			repository: "ubuntu",
+			tag:        "12.04",
+		}
+		assertSplitDockerImage(t, "localhost:8888/ubuntu:12.04", expected)
+	})
 
-func TestSplitDockerImageWithPrivateRegistryPath(t *testing.T) {
-	registry, repository, tag := SplitDockerImage("localhost:8888/ubuntu/foo:12.04")
+	t.Run("image with localhost registry on custom port and namespaced repository and tag", func(t *testing.T) {
+		expected := splitDockerImageResults{
+			registry:   "localhost:8888",
+			repository: "ubuntu/foo",
+			tag:        "12.04",
+		}
+		assertSplitDockerImage(t, "localhost:8888/ubuntu/foo:12.04", expected)
+	})
 
-	assert.Equal(t, "localhost:8888", registry)
-	assert.Equal(t, "ubuntu/foo", repository)
-	assert.Equal(t, "12.04", tag)
+	t.Run("image with namespaced repository", func(t *testing.T) {
+		expected := splitDockerImageResults{
+			registry:   "",
+			repository: "tianon/centos",
+			tag:        "",
+		}
+		assertSplitDockerImage(t, "tianon/centos", expected)
+	})
 
-	dockerImage := context.DockerImage{
-		Registry:   registry,
-		Repository: repository,
-		Tag:        tag,
-	}
-	assert.Equal(t, "localhost:8888/ubuntu/foo:12.04", dockerImage.String())
-}
-func TestSplitDockerImageWithLocalRepositoryAndTag(t *testing.T) {
-	registry, repository, tag := SplitDockerImage("localhost:8888/ubuntu:12.04")
+	t.Run("image with namespaced repository and tag", func(t *testing.T) {
+		expected := splitDockerImageResults{
+			registry:   "",
+			repository: "tianon/centos",
+			tag:        "7",
+		}
+		assertSplitDockerImage(t, "tianon/centos:7", expected)
+	})
 
-	assert.Equal(t, "localhost:8888", registry)
-	assert.Equal(t, "ubuntu", repository)
-	assert.Equal(t, "12.04", tag)
-
-	dockerImage := context.DockerImage{
-		Registry:   registry,
-		Repository: repository,
-		Tag:        tag,
-	}
-	assert.Equal(t, "localhost:8888/ubuntu:12.04", dockerImage.String())
-}
-
-func TestSplitDockerImageWithNamespacedRepository(t *testing.T) {
-	registry, repository, tag := SplitDockerImage("tianon/centos")
-
-	assert.Equal(t, "", registry)
-	assert.Equal(t, "tianon/centos", repository)
-	assert.Equal(t, "", tag)
-
-	dockerImage := context.DockerImage{
-		Registry:   registry,
-		Repository: repository,
-		Tag:        tag,
-	}
-	assert.Equal(t, "tianon/centos", dockerImage.String())
-}
-
-func TestSplitDockerImageWithNamespacedRepositoryAndTag(t *testing.T) {
-	registry, repository, tag := SplitDockerImage("tianon/centos:7")
-
-	assert.Equal(t, "", registry)
-	assert.Equal(t, "tianon/centos", repository)
-	assert.Equal(t, "7", tag)
-
-	dockerImage := context.DockerImage{
-		Registry:   registry,
-		Repository: repository,
-		Tag:        tag,
-	}
-	assert.Equal(t, "tianon/centos:7", dockerImage.String())
-}
-
-func TestSplitDockerImageWithLocalhostRegistryAndTag(t *testing.T) {
-	registry, repository, tag := SplitDockerImage("localhost/ubuntu:12.04")
-
-	assert.Equal(t, "localhost", registry)
-	assert.Equal(t, "ubuntu", repository)
-	assert.Equal(t, "12.04", tag)
-
-	dockerImage := context.DockerImage{
-		Registry:   registry,
-		Repository: repository,
-		Tag:        tag,
-	}
-	assert.Equal(t, "localhost/ubuntu:12.04", dockerImage.String())
+	t.Run("image with registry and namespaced repository and tag", func(t *testing.T) {
+		expected := splitDockerImageResults{
+			registry:   "custom.registry",
+			repository: "tianon/centos",
+			tag:        "7",
+		}
+		assertSplitDockerImage(t, "custom.registry/tianon/centos:7", expected)
+	})
 }
 
 func TestParseHostUnix(t *testing.T) {

--- a/internal/dockerclient/docker_cli_test.go
+++ b/internal/dockerclient/docker_cli_test.go
@@ -154,6 +154,36 @@ func TestSplitDockerImageWithLocalRepositoryAndTag(t *testing.T) {
 	assert.Equal(t, "localhost:8888/ubuntu:12.04", dockerImage.String())
 }
 
+func TestSplitDockerImageWithNamespacedRepository(t *testing.T) {
+	registry, repository, tag := SplitDockerImage("tianon/centos")
+
+	assert.Equal(t, "", registry)
+	assert.Equal(t, "tianon/centos", repository)
+	assert.Equal(t, "", tag)
+
+	dockerImage := context.DockerImage{
+		Registry:   registry,
+		Repository: repository,
+		Tag:        tag,
+	}
+	assert.Equal(t, "tianon/centos", dockerImage.String())
+}
+
+func TestSplitDockerImageWithNamespacedRepositoryAndTag(t *testing.T) {
+	registry, repository, tag := SplitDockerImage("tianon/centos:7")
+
+	assert.Equal(t, "", registry)
+	assert.Equal(t, "tianon/centos", repository)
+	assert.Equal(t, "7", tag)
+
+	dockerImage := context.DockerImage{
+		Registry:   registry,
+		Repository: repository,
+		Tag:        tag,
+	}
+	assert.Equal(t, "tianon/centos:7", dockerImage.String())
+}
+
 func TestParseHostUnix(t *testing.T) {
 	proto, addr, err := parseHost("unix:///var/run/docker.sock")
 	assert.NoError(t, err)


### PR DESCRIPTION
## Problem

`SplitDockerImage` treats everything before the first `/` as the registry. For Docker Hub images that use a namespace/user prefix — e.g. `tianon/centos` — this incorrectly yields `Registry="tianon"`, `Repository="centos"` instead of `Registry=""` (implicit Docker Hub) and `Repository="tianon/centos"`.

Per Docker's reference parser, the first path component is a registry **only** when it contains a `.` or `:`, or is exactly `localhost`. Otherwise it belongs to the repository path.

## Change

`SplitDockerImage` now applies that rule: the first segment is treated as the registry only when it contains `.`/`:` or equals `localhost`; otherwise the whole `user/image` is kept as the repository. Tag parsing is unchanged.

Because `DockerImage.String()` rejoins `registry + "/" + repository`, the full image string still round-trips — only the split `.Image.Registry` / `.Image.Repository` fields change, which is the intended correction for templates that read those fields.

## Tests

Added `tianon/centos` and `tianon/centos:7` cases. All existing cases (`ubuntu`, `custom.registry/…`, `localhost:8888/…`, etc.) still pass. No new dependencies.

Fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
