### PR TITLE
feat: expose container devices to templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ type RuntimeContainer struct {
     Created      time.Time
     Addresses    []Address
     Networks     []Network
+    Devices      []Device
     Gateway      string
     Name         string
     Hostname     string
@@ -326,6 +327,12 @@ type Mount struct {
   RW          bool
 }
 
+type Device struct {
+  PathOnHost      string
+  PathInContainer string
+  Permissions     string
+}
+
 type Volume struct {
     Path      string
     HostPath  string
@@ -375,6 +382,13 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
       "Proto": "tcp",
       "HostIP": "192.168.10.24",
       "HostPort": "2222"
+    }
+  ],
+  "Devices": [
+    {
+      "PathOnHost": "/dev/ttyACM0",
+      "PathInContainer": "/dev/ttyUSB0",
+      "Permissions": "rwm"
     }
   ],
   "Gateway": "172.17.42.1",

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -68,6 +68,12 @@ type Network struct {
 	Internal            bool
 }
 
+type Device struct {
+	PathOnHost      string
+	PathInContainer string
+	Permissions     string
+}
+
 type Volume struct {
 	Path      string
 	HostPath  string
@@ -88,6 +94,7 @@ type RuntimeContainer struct {
 	Created      time.Time
 	Addresses    []Address
 	Networks     []Network
+	Devices      []Device
 	Gateway      string
 	Name         string
 	Hostname     string

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -466,6 +466,7 @@ func (g *generator) getContainers(config config.Config) ([]*context.RuntimeConta
 			NetworkMode:  containerHostConfig.NetworkMode,
 			Addresses:    []context.Address{},
 			Networks:     []context.Network{},
+			Devices:      []context.Device{},
 			Env:          make(map[string]string),
 			Volumes:      make(map[string]context.Volume),
 			Node:         context.SwarmNode{},
@@ -522,6 +523,14 @@ func (g *generator) getContainers(config config.Config) ([]*context.RuntimeConta
 				Driver:      v.Driver,
 				Mode:        v.Mode,
 				RW:          v.RW,
+			})
+		}
+
+		for _, v := range containerHostConfig.Devices {
+			runtimeContainer.Devices = append(runtimeContainer.Devices, context.Device{
+				PathOnHost:      v.PathOnHost,
+				PathInContainer: v.PathInContainer,
+				Permissions:     v.CgroupPermissions,
 			})
 		}
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -191,3 +191,54 @@ func TestGetContainersNilStructs(t *testing.T) {
 	assert.Empty(t, containers[0].Addresses)
 	assert.Empty(t, containers[0].Networks)
 }
+
+func TestGetContainersDevices(t *testing.T) {
+	log.SetOutput(io.Discard)
+	containerID := "dev123456789abcd"
+
+	server, _ := dockertest.NewServer("127.0.0.1:0", nil, nil)
+	server.CustomHandler("/info", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"Containers":1,"Images":1,"NFd":11,"NGoroutines":21}`))
+	}))
+	server.CustomHandler("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"Version":"19.03.12","Os":"Linux","GoVersion":"go1.13.14","Arch":"amd64","ApiVersion":"1.40"}`))
+	}))
+	server.CustomHandler("/networks", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("[]"))
+	}))
+	server.CustomHandler("/containers/json", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]docker.APIContainers{{ID: containerID, Names: []string{"/dev-test"}}})
+	}))
+	server.CustomHandler(fmt.Sprintf("/containers/%s/json", containerID), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(docker.Container{
+			ID:   containerID,
+			Name: "/dev-test",
+			HostConfig: &docker.HostConfig{
+				Devices: []docker.Device{
+					{PathOnHost: "/dev/ttyACM0", PathInContainer: "/dev/ttyUSB0", CgroupPermissions: "rwm"},
+				},
+			},
+		})
+	}))
+
+	serverURL := fmt.Sprintf("tcp://%s", strings.TrimRight(strings.TrimPrefix(server.URL(), "http://"), "/"))
+	client, err := dockerclient.NewDockerClient(serverURL, false, "", "", "")
+	if err != nil {
+		t.Fatalf("failed to create client: %s", err)
+	}
+	client.SkipServerVersionCheck = true
+
+	apiVersion, err := client.Version()
+	if err != nil {
+		t.Fatalf("failed to retrieve version: %s", err)
+	}
+	context.SetDockerEnv(apiVersion)
+
+	g := &generator{Client: client, Endpoint: serverURL}
+	containers, err := g.getContainers(config.Config{})
+	assert.NoError(t, err)
+	assert.Len(t, containers, 1)
+	assert.Equal(t, []context.Device{
+		{PathOnHost: "/dev/ttyACM0", PathInContainer: "/dev/ttyUSB0", Permissions: "rwm"},
+	}, containers[0].Devices)
+}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -193,10 +193,16 @@ func TestGetContainersNilStructs(t *testing.T) {
 }
 
 func TestGetContainersDevices(t *testing.T) {
+	orig := log.Writer()
 	log.SetOutput(io.Discard)
+	t.Cleanup(func() { log.SetOutput(orig) })
 	containerID := "dev123456789abcd"
 
-	server, _ := dockertest.NewServer("127.0.0.1:0", nil, nil)
+	server, err := dockertest.NewServer("127.0.0.1:0", nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create test server: %s", err)
+	}
+	t.Cleanup(server.Stop)
 	server.CustomHandler("/info", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"Containers":1,"Images":1,"NFd":11,"NGoroutines":21}`))
 	}))


### PR DESCRIPTION
## Summary

Exposes container device passthrough (`HostConfig.Devices`) to templates, reimplementing the stale PR #277 against the current `internal/` layout.

- Adds a `Device{PathOnHost, PathInContainer, Permissions}` type and a `Devices []Device` field on `RuntimeContainer`.
- Populates it in `getContainers`, mirroring the existing Mounts loop. go-dockerclient's `Device.CgroupPermissions` is mapped to `Device.Permissions`.

Use case: discovering forwarded device nodes (webcams, USB-serial adapters, etc.) from templates.

## Notes

- The populate loop iterates the nil-safe local copy of `HostConfig` (introduced in #748) instead of dereferencing `container.HostConfig` directly, so a container inspected with a nil `HostConfig` cannot panic.
- The unrelated `t.Fatal`→`t.Fatalf` churn from the original PR is dropped.
- `HostConfig.Devices` has been stable in go-dockerclient since 2018, so no dependency change is required.

## Tests

Added `TestGetContainersDevices`, which drives `getContainers` against a mock daemon returning a device and asserts the populated `Devices`. Documented the `Device` struct and a JSON example in the README.

Reimplements #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)
