### PR TITLE
fix: better entrypoint logic

### DIFF
--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -eu
 
+# If no arguments are passed, default to running docker-gen
+if [ "$#" -eq 0 ]; then
+	set -- docker-gen
+fi
+
 # Prepend docker-gen unless $1 resolves to an executable regular file
 _cmd="$(command -v -- "$1" 2>/dev/null)"
 if [ -f "$_cmd" ] && [ -x "$_cmd" ]; then

--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -2,7 +2,13 @@
 
 set -eu
 
-# run container's CMD if it is an executable in PATH
-command -v -- "$1" >/dev/null 2>&1 || set -- docker-gen "$@"
+# Prepend docker-gen unless $1 resolves to an executable regular file
+_cmd="$(command -v -- "$1" 2>/dev/null)"
+if [ -f "$_cmd" ] && [ -x "$_cmd" ]; then
+	:
+else
+	set -- docker-gen "$@"
+fi
+unset _cmd
 
 exec "$@"


### PR DESCRIPTION
This PR fixes #628 (don't treat non executable file path passed to the entrypoint as executable), with an additional fix (run docker-gen without argument when no argument are passed to the entrypoint, rather than failing because of `set -e`).

```
$ docker run -it --rm -v /var/run/docker.sock:/tmp/docker.sock:ro --entrypoint ash nginxproxy/docker-gen:628
$ echo Hello world > template.tmpl

$ docker-gen /template.tmpl 
Hello world

$ /app/docker-entrypoint.sh /template.tmpl 
Hello world
```