### PR TITLE
ci: add image base to build job name

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   multiarch-build:
-    name: Build and publish image
+    name: Build and publish ${{ matrix.base }} image
     strategy:
       matrix:
         base: [alpine, debian]


### PR DESCRIPTION
Minor change to re-trigger the build workflow and possibly solve #764 