### PR TITLE
feat: basic template validation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,8 @@ server {{ $net.IP }}:{{ (index $value.Addresses 0).Port }};
 - _`include $file`_: Returns content of `$file`, and empty string if file reading error.
 - _`intersect $slice1 $slice2`_: Returns the strings that exist in both string slices.
 - _`mustBeOneOf $slice $value`_: Validates that `$value` is one of the allowed string values in `$slice`, returns `$value` on success and an error otherwise.
+- _`mustBeInt $value`_: Validates that `$value` is a base-10 integer string, returns `$value` on success and an error otherwise.
+- _`mustBeIntInRange $min $max $value`_: Validates that `$value` is a base-10 integer string in the inclusive range `$min..$max`, returns `$value` on success and an error otherwise.
 - _`fromYaml $string` / `mustFromYaml $string`_: Similar to [Sprig's `fromJson` / `mustFromJson`](https://github.com/Masterminds/sprig/blob/master/docs/defaults.md#fromjson-mustfromjson), but for YAML.
 - _`toYaml $dict` / `mustToYaml $dict`_: Similar to [Sprig's `toJson` / `mustToJson`](https://github.com/Masterminds/sprig/blob/master/docs/defaults.md#tojson-musttojson), but for YAML.
 - _`keys $map`_: Returns the keys from `$map`. If `$map` is `nil`, a `nil` is returned. If `$map` is not a `map`, an error will be thrown.

--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ server {{ $net.IP }}:{{ (index $value.Addresses 0).Port }};
 - _`groupByLabelWithDefault $containers $label $defaultValue`_: Returns the same as `groupBy` but grouping by the given label's value. Containers that do not have the `$label` set are included in the map under the `$defaultValue` key.
 - _`include $file`_: Returns content of `$file`, and empty string if file reading error.
 - _`intersect $slice1 $slice2`_: Returns the strings that exist in both string slices.
+- _`mustBeOneOf $slice $value`_: Validates that `$value` is one of the allowed string values in `$slice`, returns `$value` on success and an error otherwise.
 - _`fromYaml $string` / `mustFromYaml $string`_: Similar to [Sprig's `fromJson` / `mustFromJson`](https://github.com/Masterminds/sprig/blob/master/docs/defaults.md#fromjson-mustfromjson), but for YAML.
 - _`toYaml $dict` / `mustToYaml $dict`_: Similar to [Sprig's `toJson` / `mustToJson`](https://github.com/Masterminds/sprig/blob/master/docs/defaults.md#tojson-musttojson), but for YAML.
 - _`keys $map`_: Returns the keys from `$map`. If `$map` is `nil`, a `nil` is returned. If `$map` is not a `map`, an error will be thrown.

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -104,6 +104,9 @@ func newTemplate(name string) *template.Template {
 		"whereLabelDoesNotExist":  whereLabelDoesNotExist,
 		"whereLabelValueMatches":  whereLabelValueMatches,
 
+		// validation functions
+		"mustBeOneOf": mustBeOneOf,
+
 		// legacy docker-gen template function aliased to their Sprig clone
 		"json":      sprigFuncMap["mustToJson"],
 		"parseJson": sprigFuncMap["mustFromJson"],

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -105,7 +105,9 @@ func newTemplate(name string) *template.Template {
 		"whereLabelValueMatches":  whereLabelValueMatches,
 
 		// validation functions
-		"mustBeOneOf": mustBeOneOf,
+		"mustBeOneOf":      mustBeOneOf,
+		"mustBeInt":        mustBeInt,
+		"mustBeIntInRange": mustBeIntInRange,
 
 		// legacy docker-gen template function aliased to their Sprig clone
 		"json":      sprigFuncMap["mustToJson"],

--- a/internal/template/validation.go
+++ b/internal/template/validation.go
@@ -2,7 +2,9 @@ package template
 
 import (
 	"fmt"
+	"math"
 	"slices"
+	"strconv"
 )
 
 // mustBeOneOf validates that value matches one of the allowed string values.
@@ -26,4 +28,31 @@ func mustBeOneOf(allowed []any, value string) (string, error) {
 		strAllowed,
 		value,
 	)
+}
+
+// mustBeInt validates that value is a base-10 integer string.
+func mustBeInt(value string) (string, error) {
+	return mustBeIntInRange(math.MinInt, math.MaxInt, value)
+}
+
+// mustBeIntInRange validates that value is a base-10 integer string within min..max (inclusive).
+func mustBeIntInRange(min, max int, value string) (string, error) {
+	if min > max {
+		return "", fmt.Errorf("invalid allowed range %d..%d", min, max)
+	}
+
+	if value == "" {
+		return "", fmt.Errorf("value must be an integer; got an empty value")
+	}
+
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("value must be an integer; got %q", value)
+	}
+
+	if parsed < int64(min) || parsed > int64(max) {
+		return "", fmt.Errorf("value must be an integer between %d and %d; got %q", min, max, value)
+	}
+
+	return value, nil
 }

--- a/internal/template/validation.go
+++ b/internal/template/validation.go
@@ -1,0 +1,29 @@
+package template
+
+import (
+	"fmt"
+	"slices"
+)
+
+// mustBeOneOf validates that value matches one of the allowed string values.
+func mustBeOneOf(allowed []any, value string) (string, error) {
+	strAllowed := make([]string, len(allowed))
+
+	for i, candidate := range allowed {
+		strAllowedValue, ok := candidate.(string)
+		if !ok {
+			return "", fmt.Errorf("allowed value %v (type %T) is not a string", candidate, candidate)
+		}
+		strAllowed[i] = strAllowedValue
+	}
+
+	if slices.Contains(strAllowed, value) {
+		return value, nil
+	}
+
+	return "", fmt.Errorf(
+		"value must be one of %q; got %q",
+		strAllowed,
+		value,
+	)
+}

--- a/internal/template/validation_test.go
+++ b/internal/template/validation_test.go
@@ -1,0 +1,61 @@
+package template
+
+import "testing"
+
+func TestMustBeOneOf(t *testing.T) {
+	testCases := []struct {
+		name          string
+		allowedValues []any
+		input         string
+		wantValue     string
+		wantErr       bool
+		errSnippet    string
+	}{
+		{
+			name:          "valid input value",
+			allowedValues: []any{"a", "b", "c"},
+			input:         "a",
+			wantValue:     "a",
+		},
+		{
+			name:          "invalid input value",
+			allowedValues: []any{"a", "b", "c"},
+			input:         "d",
+			wantErr:       true,
+			errSnippet:    `value must be one of ["a" "b" "c"]`,
+		},
+		{
+			name:          "non-string allowed value",
+			allowedValues: []any{"a", 1, "c"},
+			input:         "a",
+			wantErr:       true,
+			errSnippet:    "is not a string",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := mustBeOneOf(tc.allowedValues, tc.input)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("mustBeOneOf(%v, %q) expected an error; got nil", tc.allowedValues, tc.input)
+				}
+				if got != "" {
+					t.Fatalf("mustBeOneOf(%v, %q) returned unexpected value on error: %q", tc.allowedValues, tc.input, got)
+				}
+				if tc.errSnippet != "" && !strings.Contains(err.Error(), tc.errSnippet) {
+					t.Fatalf("mustBeOneOf(%v, %q) error %q does not contain %q", tc.allowedValues, tc.input, err.Error(), tc.errSnippet)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("mustBeOneOf(%v, %q) returned unexpected error: %v", tc.allowedValues, tc.input, err)
+			}
+			if got != tc.wantValue {
+				t.Fatalf("mustBeOneOf(%v, %q) returned %q; want %q", tc.allowedValues, tc.input, got, tc.wantValue)
+			}
+		})
+	}
+}

--- a/internal/template/validation_test.go
+++ b/internal/template/validation_test.go
@@ -1,6 +1,9 @@
 package template
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestMustBeOneOf(t *testing.T) {
 	testCases := []struct {
@@ -55,6 +58,177 @@ func TestMustBeOneOf(t *testing.T) {
 			}
 			if got != tc.wantValue {
 				t.Fatalf("mustBeOneOf(%v, %q) returned %q; want %q", tc.allowedValues, tc.input, got, tc.wantValue)
+			}
+		})
+	}
+}
+
+func TestMustBeInt(t *testing.T) {
+	testCases := []struct {
+		name       string
+		input      string
+		wantValue  string
+		wantErr    bool
+		errSnippet string
+	}{
+		{
+			name:      "valid zero value",
+			input:     "0",
+			wantValue: "0",
+		},
+		{
+			name:      "valid positive value",
+			input:     "161",
+			wantValue: "161",
+		},
+		{
+			name:      "valid negative value",
+			input:     "-42",
+			wantValue: "-42",
+		},
+		{
+			name:       "empty value is rejected",
+			input:      "",
+			wantErr:    true,
+			errSnippet: "empty value",
+		},
+		{
+			name:       "non integer value is rejected",
+			input:      "abc",
+			wantErr:    true,
+			errSnippet: "must be an integer",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := mustBeInt(tc.input)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("mustBeInt(%q) expected an error; got nil", tc.input)
+				}
+				if got != "" {
+					t.Fatalf("mustBeInt(%q) returned unexpected value on error: %q", tc.input, got)
+				}
+				if tc.errSnippet != "" && !strings.Contains(err.Error(), tc.errSnippet) {
+					t.Fatalf("mustBeInt(%q) error %q does not contain %q", tc.input, err.Error(), tc.errSnippet)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("mustBeInt(%q) returned unexpected error: %v", tc.input, err)
+			}
+			if got != tc.wantValue {
+				t.Fatalf("mustBeInt(%q) returned %q; want %q", tc.input, got, tc.wantValue)
+			}
+		})
+	}
+}
+
+func TestMustBeIntInRange(t *testing.T) {
+	testCases := []struct {
+		name       string
+		min        int
+		max        int
+		input      string
+		wantValue  string
+		wantErr    bool
+		errSnippet string
+	}{
+		{
+			name:      "value in range",
+			min:       -3,
+			max:       3,
+			input:     "2",
+			wantValue: "2",
+		},
+		{
+			name:      "value at lower boundary",
+			min:       -3,
+			max:       3,
+			input:     "-3",
+			wantValue: "-3",
+		},
+		{
+			name:      "value at upper boundary",
+			min:       -3,
+			max:       3,
+			input:     "3",
+			wantValue: "3",
+		},
+		{
+			name:       "invalid allowed range",
+			min:        5,
+			max:        -10,
+			input:      "3",
+			wantErr:    true,
+			errSnippet: "invalid allowed range",
+		},
+		{
+			name:       "empty value is rejected",
+			min:        -3,
+			max:        3,
+			input:      "",
+			wantErr:    true,
+			errSnippet: "empty value",
+		},
+		{
+			name:       "non integer value is rejected",
+			min:        -3,
+			max:        3,
+			input:      "abc",
+			wantErr:    true,
+			errSnippet: "must be an integer",
+		},
+		{
+			name:       "value below minimum is rejected",
+			min:        -3,
+			max:        3,
+			input:      "-4",
+			wantErr:    true,
+			errSnippet: "between -3 and 3",
+		},
+		{
+			name:       "value above maximum is rejected",
+			min:        -3,
+			max:        3,
+			input:      "4",
+			wantErr:    true,
+			errSnippet: "between -3 and 3",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := mustBeIntInRange(tc.min, tc.max, tc.input)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("mustBeIntInRange(%d, %d, %q) expected an error; got nil", tc.min, tc.max, tc.input)
+				}
+				if got != "" {
+					t.Fatalf("mustBeIntInRange(%d, %d, %q) returned unexpected value on error: %q", tc.min, tc.max, tc.input, got)
+				}
+				if tc.errSnippet != "" && !strings.Contains(err.Error(), tc.errSnippet) {
+					t.Fatalf(
+						"mustBeIntInRange(%d, %d, %q) error %q does not contain %q",
+						tc.min,
+						tc.max,
+						tc.input,
+						err.Error(),
+						tc.errSnippet,
+					)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("mustBeIntInRange(%d, %d, %q) returned unexpected error: %v", tc.min, tc.max, tc.input, err)
+			}
+			if got != tc.wantValue {
+				t.Fatalf("mustBeIntInRange(%d, %d, %q) returned %q; want %q", tc.min, tc.max, tc.input, got, tc.wantValue)
 			}
 		})
 	}


### PR DESCRIPTION
This PR introduce three template functions intended to be used as validators.

All three take a string as last input and either return it unmodified or return an error, so that they can be used in a go template pipeline and prevent docker-gen from rendering the template if their respective validation fail.

- _`mustBeOneOf $slice $value`_: Validates that `$value` is one of the allowed string values in `$slice`.
- _`mustBeInt $value`_: Validates that `$value` is a base-10 integer string.
- _`mustBeIntInRange $min $max $value`_: Validates that `$value` is a base-10 integer string in the inclusive range `$min..$max`.

Example use:
```
{{ $value := somePipeline }}
{{ $allowedValues := list "foo" "bar" "baz" }}
{{ $sanitizedValue := $value | trim | mustBeOneOf $allowedValues }}
{{ /* the template rendering will fail at the above line if ($value | trim) does not evaluate as "foo", "bar" or "baz" /* }}
```